### PR TITLE
defuse and reveal

### DIFF
--- a/apps/capsulelabs-api/src/capsules/timebomb/dto/defuse-request.dto.ts
+++ b/apps/capsulelabs-api/src/capsules/timebomb/dto/defuse-request.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from "class-validator"
+
+export class DefuseRequestDto {
+  @IsNotEmpty()
+  @IsString()
+  username: string // Username of the user attempting to defuse
+}

--- a/apps/capsulelabs-api/src/capsules/timebomb/dto/defuse-response.dto.ts
+++ b/apps/capsulelabs-api/src/capsules/timebomb/dto/defuse-response.dto.ts
@@ -1,0 +1,9 @@
+import type { ContentType } from "../../base-capsule.schema"
+
+export class DefuseResponseDto {
+  id: string
+  contentType: ContentType
+  content: string // Either the message text or media URL
+  defused: boolean
+  isMaxDefusersReached: boolean
+}

--- a/apps/capsulelabs-api/src/capsules/timebomb/timebomb-capsule.controller.ts
+++ b/apps/capsulelabs-api/src/capsules/timebomb/timebomb-capsule.controller.ts
@@ -3,19 +3,16 @@ import type { TimeBombCapsuleService } from "./timebomb-capsule.service"
 import type { PlantTimeBombDto } from "./dto/plant-timebomb.dto"
 import { TimeBombResponseDto } from "./dto/timebomb-response.dto"
 import type { NearbyRequestDto } from "./dto/nearby-request.dto"
-import { Controller, Post, Body, Get, Param } from "@nestjs/common"
-import type { TimeBombCapsuleService } from "./timebomb-capsule.service"
-import type { PlantTimeBombDto } from "./dto/plant-timebomb.dto"
-import { TimeBombResponseDto } from "./dto/timebomb-response.dto"
+import type { NearbyCapsuleDto } from "./dto/nearby-response.dto"
+import type { DefuseRequestDto } from "./dto/defuse-request.dto"
+import type { DefuseResponseDto } from "./dto/defuse-response.dto"
 
 @Controller("timebomb")
 export class TimeBombCapsuleController {
   constructor(private readonly timeBombService: TimeBombCapsuleService) {}
 
   @Post("plant")
-  async plantTimeBomb(
-    @Body() plantTimeBombDto: PlantTimeBombDto,
-  ): Promise<TimeBombResponseDto> {
+  async plantTimeBomb(@Body() plantTimeBombDto: PlantTimeBombDto): Promise<TimeBombResponseDto> {
     const timeBomb = await this.timeBombService.plantTimeBomb(plantTimeBombDto);
     return new TimeBombResponseDto(timeBomb);
   }
@@ -29,5 +26,13 @@ export class TimeBombCapsuleController {
   @Get("nearby")
   async findNearby(@Query() nearbyRequestDto: NearbyRequestDto): Promise<NearbyCapsuleDto[]> {
     return this.timeBombService.findNearby(nearbyRequestDto)
+  }
+
+  @Post(":id/defuse")
+  async defuseTimeBomb(
+    @Param("id") id: string,
+    @Body() defuseRequestDto: DefuseRequestDto,
+  ): Promise<DefuseResponseDto> {
+    return this.timeBombService.defuseTimeBomb(id, defuseRequestDto)
   }
 }

--- a/apps/capsulelabs-api/src/exceptions/http-exception.filter.ts
+++ b/apps/capsulelabs-api/src/exceptions/http-exception.filter.ts
@@ -1,0 +1,39 @@
+import { type ExceptionFilter, Catch, type ArgumentsHost, HttpException, HttpStatus, Logger } from "@nestjs/common"
+import type { Request, Response } from "express"
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(HttpExceptionFilter.name)
+
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp()
+    const response = ctx.getResponse<Response>()
+    const request = ctx.getRequest<Request>()
+    const status = exception.getStatus()
+
+    const errorResponse = {
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+      method: request.method,
+      message: exception.message || null,
+      error: exception.name,
+    }
+
+    if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
+      this.logger.error(
+        `${request.method} ${request.url}`,
+        exception.stack,
+        `${request.ip} ${request.get("user-agent") || ""}`,
+      )
+    } else {
+      this.logger.warn(
+        `${request.method} ${request.url} ${status}`,
+        `${exception.message}`,
+        `${request.ip} ${request.get("user-agent") || ""}`,
+      )
+    }
+
+    response.status(status).json(errorResponse)
+  }
+}


### PR DESCRIPTION
### Add Defuse Endpoint for TimeBomb Capsules

Implements `POST /timebomb/:id/defuse` allowing users to attempt defusal of a TimeBomb capsule. Rejects attempts if expired or previously defused by the user. If the maximum number of defusers is reached, the capsule is marked as defused. Successful attempts return the capsule's full content.

closes #8 