### PR TITLE
Feat/heartbeat capsule :  Implement Heartbeat Capsule Feature

### DIFF
--- a/apps/capsulelabs-api/src/capsules/heartbeat-capsule/dto/create-heartbeat-capsule.dto.ts
+++ b/apps/capsulelabs-api/src/capsules/heartbeat-capsule/dto/create-heartbeat-capsule.dto.ts
@@ -1,0 +1,26 @@
+import { IsNotEmpty, IsString, IsInt, Min, Max } from "class-validator"
+import { ApiProperty } from "@nestjs/swagger"
+
+export class CreateHeartbeatCapsuleDto {
+  @ApiProperty({ description: "Title of the heartbeat capsule" })
+  @IsNotEmpty()
+  @IsString()
+  title: string
+
+  @ApiProperty({ description: "Content of the heartbeat capsule" })
+  @IsNotEmpty()
+  @IsString()
+  content: string
+
+  @ApiProperty({ description: "Minimum target BPM for unlocking the capsule", minimum: 30, maximum: 220 })
+  @IsInt()
+  @Min(30)
+  @Max(220)
+  targetMinBpm: number
+
+  @ApiProperty({ description: "Maximum target BPM for unlocking the capsule", minimum: 30, maximum: 220 })
+  @IsInt()
+  @Min(30)
+  @Max(220)
+  targetMaxBpm: number
+}

--- a/apps/capsulelabs-api/src/capsules/heartbeat-capsule/dto/submit-bpm.dto.ts
+++ b/apps/capsulelabs-api/src/capsules/heartbeat-capsule/dto/submit-bpm.dto.ts
@@ -1,0 +1,10 @@
+import { IsInt, Min, Max } from "class-validator"
+import { ApiProperty } from "@nestjs/swagger"
+
+export class SubmitBpmDto {
+  @ApiProperty({ description: "Heart rate in beats per minute", minimum: 30, maximum: 220 })
+  @IsInt()
+  @Min(30)
+  @Max(220)
+  bpm: number
+}

--- a/apps/capsulelabs-api/src/capsules/heartbeat-capsule/dto/view-heartbeat-capsule.dto.ts
+++ b/apps/capsulelabs-api/src/capsules/heartbeat-capsule/dto/view-heartbeat-capsule.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from "@nestjs/swagger"
+
+export class ViewHeartbeatCapsuleDto {
+  @ApiProperty()
+  id: string
+
+  @ApiProperty()
+  title: string
+
+  @ApiProperty({ required: false })
+  content?: string
+
+  @ApiProperty()
+  isLocked: boolean
+
+  @ApiProperty()
+  targetMinBpm: number
+
+  @ApiProperty()
+  targetMaxBpm: number
+
+  @ApiProperty({ required: false })
+  submittedBpm?: number
+
+  @ApiProperty()
+  createdAt: Date
+
+  @ApiProperty()
+  updatedAt: Date
+}

--- a/apps/capsulelabs-api/src/capsules/heartbeat-capsule/entities/bpm-submission.entity.ts
+++ b/apps/capsulelabs-api/src/capsules/heartbeat-capsule/entities/bpm-submission.entity.ts
@@ -1,0 +1,30 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, ManyToOne, JoinColumn } from "typeorm"
+import { HeartbeatCapsule } from "./heartbeat-capsule.entity"
+
+@Entity("bpm_submissions")
+export class BpmSubmission {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column()
+  userId: string
+
+  @Column("int")
+  bpm: number
+
+  @Column()
+  successful: boolean
+
+  @Column()
+  capsuleId: string
+
+  @ManyToOne(
+    () => HeartbeatCapsule,
+    (capsule) => capsule.bpmSubmissions,
+  )
+  @JoinColumn({ name: "capsuleId" })
+  capsule: HeartbeatCapsule
+
+  @CreateDateColumn()
+  createdAt: Date
+}

--- a/apps/capsulelabs-api/src/capsules/heartbeat-capsule/entities/heartbeat-capsule.entity.ts
+++ b/apps/capsulelabs-api/src/capsules/heartbeat-capsule/entities/heartbeat-capsule.entity.ts
@@ -1,0 +1,35 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, OneToMany } from "typeorm"
+import { BpmSubmission } from "./bpm-submission.entity"
+
+@Entity("heartbeat_capsules")
+export class HeartbeatCapsule {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column()
+  title: string
+
+  @Column("text")
+  content: string
+
+  @Column()
+  userId: string
+
+  @Column("int")
+  targetMinBpm: number
+
+  @Column("int")
+  targetMaxBpm: number
+
+  @OneToMany(
+    () => BpmSubmission,
+    (submission) => submission.capsule,
+  )
+  bpmSubmissions: BpmSubmission[]
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+}

--- a/apps/capsulelabs-api/src/capsules/heartbeat-capsule/heartbeat-capsule.controller.ts
+++ b/apps/capsulelabs-api/src/capsules/heartbeat-capsule/heartbeat-capsule.controller.ts
@@ -1,0 +1,113 @@
+import { Controller, Get, Post, Body, Param, UseGuards, Request, HttpStatus } from "@nestjs/common"
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from "@nestjs/swagger"
+import type { HeartbeatCapsuleService } from "./heartbeat-capsule.service"
+import type { CreateHeartbeatCapsuleDto } from "./dto/create-heartbeat-capsule.dto"
+import type { SubmitBpmDto } from "./dto/submit-bpm.dto"
+import { ViewHeartbeatCapsuleDto } from "./dto/view-heartbeat-capsule.dto"
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard"
+
+@ApiTags("heartbeat-capsules")
+@Controller("capsules/heartbeat")
+export class HeartbeatCapsuleController {
+  constructor(private readonly heartbeatCapsuleService: HeartbeatCapsuleService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Create a new heartbeat capsule" })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: "The capsule has been successfully created.",
+    type: ViewHeartbeatCapsuleDto,
+  })
+  async create(@Body() createHeartbeatCapsuleDto: CreateHeartbeatCapsuleDto, @Request() req: any) {
+    const capsule = await this.heartbeatCapsuleService.create(createHeartbeatCapsuleDto, req.user.id)
+    return {
+      id: capsule.id,
+      title: capsule.title,
+      isLocked: true,
+      targetMinBpm: capsule.targetMinBpm,
+      targetMaxBpm: capsule.targetMaxBpm,
+      createdAt: capsule.createdAt,
+      updatedAt: capsule.updatedAt,
+    }
+  }
+
+  @Get()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Get all heartbeat capsules for the current user" })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "Returns all capsules for the user",
+    type: [ViewHeartbeatCapsuleDto],
+  })
+  async findAll(@Request() req) {
+    const capsules = await this.heartbeatCapsuleService.findAll(req.user.id)
+    return capsules.map(capsule => ({
+      id: capsule.id,
+      title: capsule.title,
+      isLocked: true,
+      targetMinBpm: capsule.targetMinBpm,
+      targetMaxBpm: capsule.targetMaxBpm,
+      createdAt: capsule.createdAt,
+      updatedAt: capsule.updatedAt,
+    }))
+  }
+
+  @Get(":id")
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Get a heartbeat capsule by ID" })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "Returns the capsule information (locked by default)",
+    type: ViewHeartbeatCapsuleDto,
+  })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Capsule not found" })
+  async findOne(@Param('id') id: string, @Request() req) {
+    const capsule = await this.heartbeatCapsuleService.findOne(id)
+
+    // Check if the user is the owner of the capsule
+    if (capsule.userId !== req.user.id) {
+      throw new Error("You don't have permission to access this capsule")
+    }
+
+    return {
+      id: capsule.id,
+      title: capsule.title,
+      isLocked: true,
+      targetMinBpm: capsule.targetMinBpm,
+      targetMaxBpm: capsule.targetMaxBpm,
+      createdAt: capsule.createdAt,
+      updatedAt: capsule.updatedAt,
+    }
+  }
+
+  @Post(":id/unlock")
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Submit BPM and try to unlock a capsule" })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "Returns the capsule with content if BPM is within range",
+    type: ViewHeartbeatCapsuleDto,
+  })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Capsule not found" })
+  unlockCapsule(@Param('id') id: string, @Body() submitBpmDto: SubmitBpmDto, @Request() req) {
+    return this.heartbeatCapsuleService.unlockCapsule(id, submitBpmDto, req.user.id)
+  }
+
+  @Get(":id/history")
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Get BPM submission history for a capsule" })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "Returns the BPM submission history",
+  })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Capsule not found" })
+  getSubmissionHistory(@Param('id') id: string, @Request() req) {
+    return this.heartbeatCapsuleService.getSubmissionHistory(id, req.user.id)
+  }
+}

--- a/apps/capsulelabs-api/src/capsules/heartbeat-capsule/heartbeat-capsule.module.ts
+++ b/apps/capsulelabs-api/src/capsules/heartbeat-capsule/heartbeat-capsule.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { HeartbeatCapsuleController } from "./heartbeat-capsule.controller"
+import { HeartbeatCapsuleService } from "./heartbeat-capsule.service"
+import { HeartbeatCapsule } from "./entities/heartbeat-capsule.entity"
+import { BpmSubmission } from "./entities/bpm-submission.entity"
+
+@Module({
+  imports: [TypeOrmModule.forFeature([HeartbeatCapsule, BpmSubmission])],
+  controllers: [HeartbeatCapsuleController],
+  providers: [HeartbeatCapsuleService],
+  exports: [HeartbeatCapsuleService],
+})
+export class HeartbeatCapsuleModule {}

--- a/apps/capsulelabs-api/src/capsules/heartbeat-capsule/heartbeat-capsule.service.ts
+++ b/apps/capsulelabs-api/src/capsules/heartbeat-capsule/heartbeat-capsule.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, NotFoundException } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import type { HeartbeatCapsule } from "./entities/heartbeat-capsule.entity"
+import type { BpmSubmission } from "./entities/bpm-submission.entity"
+import type { CreateHeartbeatCapsuleDto } from "./dto/create-heartbeat-capsule.dto"
+import type { SubmitBpmDto } from "./dto/submit-bpm.dto"
+import type { ViewHeartbeatCapsuleDto } from "./dto/view-heartbeat-capsule.dto"
+
+@Injectable()
+export class HeartbeatCapsuleService {
+  constructor(
+    private readonly heartbeatCapsuleRepository: Repository<HeartbeatCapsule>,
+    private readonly bpmSubmissionRepository: Repository<BpmSubmission>,
+  ) {}
+
+  async create(createHeartbeatCapsuleDto: CreateHeartbeatCapsuleDto, userId: string): Promise<HeartbeatCapsule> {
+    // Validate that min BPM is less than max BPM
+    if (createHeartbeatCapsuleDto.targetMinBpm > createHeartbeatCapsuleDto.targetMaxBpm) {
+      throw new Error("Minimum BPM must be less than or equal to maximum BPM")
+    }
+
+    const capsule = this.heartbeatCapsuleRepository.create({
+      ...createHeartbeatCapsuleDto,
+      userId,
+    })
+
+    return this.heartbeatCapsuleRepository.save(capsule)
+  }
+
+  async findOne(id: string): Promise<HeartbeatCapsule> {
+    const capsule = await this.heartbeatCapsuleRepository.findOne({ where: { id } })
+
+    if (!capsule) {
+      throw new NotFoundException(`Heartbeat capsule with ID ${id} not found`)
+    }
+
+    return capsule
+  }
+
+  async findAll(userId: string): Promise<HeartbeatCapsule[]> {
+    return this.heartbeatCapsuleRepository.find({
+      where: { userId },
+    })
+  }
+
+  async unlockCapsule(id: string, submitBpmDto: SubmitBpmDto, userId: string): Promise<ViewHeartbeatCapsuleDto> {
+    const capsule = await this.findOne(id)
+
+    // Check if the user is the owner of the capsule
+    if (capsule.userId !== userId) {
+      throw new Error("You don't have permission to access this capsule")
+    }
+
+    const { bpm } = submitBpmDto
+    const isWithinRange = bpm >= capsule.targetMinBpm && bpm <= capsule.targetMaxBpm
+
+    // Log the BPM submission
+    await this.logBpmSubmission(capsule.id, userId, bpm, isWithinRange)
+
+    // Create the response DTO
+    const response: ViewHeartbeatCapsuleDto = {
+      id: capsule.id,
+      title: capsule.title,
+      isLocked: !isWithinRange,
+      targetMinBpm: capsule.targetMinBpm,
+      targetMaxBpm: capsule.targetMaxBpm,
+      submittedBpm: bpm,
+      createdAt: capsule.createdAt,
+      updatedAt: capsule.updatedAt,
+    }
+
+    // Only include content if BPM is within range
+    if (isWithinRange) {
+      response.content = capsule.content
+    }
+
+    return response
+  }
+
+  private async logBpmSubmission(capsuleId: string, userId: string, bpm: number, successful: boolean): Promise<void> {
+    const submission = this.bpmSubmissionRepository.create({
+      capsuleId,
+      userId,
+      bpm,
+      successful,
+    })
+
+    await this.bpmSubmissionRepository.save(submission)
+  }
+
+  async getSubmissionHistory(capsuleId: string, userId: string): Promise<BpmSubmission[]> {
+    const capsule = await this.findOne(capsuleId)
+
+    // Check if the user is the owner of the capsule
+    if (capsule.userId !== userId) {
+      throw new Error("You don't have permission to access this capsule's history")
+    }
+
+    return this.bpmSubmissionRepository.find({
+      where: { capsuleId },
+      order: { createdAt: "DESC" },
+    })
+  }
+}

--- a/apps/capsulelabs-api/src/capsules/heartbeat-capsule/seed/heartbeat-capsule.seed.ts
+++ b/apps/capsulelabs-api/src/capsules/heartbeat-capsule/seed/heartbeat-capsule.seed.ts
@@ -1,0 +1,43 @@
+import { Injectable } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import type { HeartbeatCapsule } from "../entities/heartbeat-capsule.entity"
+
+@Injectable()
+export class HeartbeatCapsuleSeed {
+  constructor(private readonly heartbeatCapsuleRepository: Repository<HeartbeatCapsule>) {}
+
+  async seed(): Promise<void> {
+    // Clear existing data
+    await this.heartbeatCapsuleRepository.clear()
+
+    // Seed data with different BPM ranges
+    const capsules = [
+      {
+        title: "Relaxation Capsule",
+        content: "This content is only visible when you're relaxed (55-75 BPM).",
+        userId: "seed-user-1",
+        targetMinBpm: 55,
+        targetMaxBpm: 75,
+      },
+      {
+        title: "Exercise Capsule",
+        content: "This content is only visible during moderate exercise (100-120 BPM).",
+        userId: "seed-user-1",
+        targetMinBpm: 100,
+        targetMaxBpm: 120,
+      },
+      {
+        title: "Meditation Capsule",
+        content: "This content is only visible during deep meditation (40-60 BPM).",
+        userId: "seed-user-2",
+        targetMinBpm: 40,
+        targetMaxBpm: 60,
+      },
+    ]
+
+    // Save all capsules
+    await this.heartbeatCapsuleRepository.save(capsules)
+
+    console.log("Heartbeat capsule seed data created successfully")
+  }
+}

--- a/apps/capsulelabs-api/src/capsules/heartbeat-capsule/test/heartbeat-capsule.controller.spec.ts
+++ b/apps/capsulelabs-api/src/capsules/heartbeat-capsule/test/heartbeat-capsule.controller.spec.ts
@@ -1,0 +1,158 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { HeartbeatCapsuleController } from "../heartbeat-capsule.controller"
+import { HeartbeatCapsuleService } from "../heartbeat-capsule.service"
+import type { CreateHeartbeatCapsuleDto } from "../dto/create-heartbeat-capsule.dto"
+import type { SubmitBpmDto } from "../dto/submit-bpm.dto"
+import type { ViewHeartbeatCapsuleDto } from "../dto/view-heartbeat-capsule.dto"
+
+describe("HeartbeatCapsuleController", () => {
+  let controller: HeartbeatCapsuleController
+  let service: HeartbeatCapsuleService
+
+  const mockHeartbeatCapsuleService = {
+    create: jest.fn(),
+    findOne: jest.fn(),
+    findAll: jest.fn(),
+    unlockCapsule: jest.fn(),
+    getSubmissionHistory: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HeartbeatCapsuleController],
+      providers: [
+        {
+          provide: HeartbeatCapsuleService,
+          useValue: mockHeartbeatCapsuleService,
+        },
+      ],
+    }).compile()
+
+    controller = module.get<HeartbeatCapsuleController>(HeartbeatCapsuleController)
+    service = module.get<HeartbeatCapsuleService>(HeartbeatCapsuleService)
+  })
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined()
+  })
+
+  describe("create", () => {
+    it("should create a heartbeat capsule", async () => {
+      const createDto: CreateHeartbeatCapsuleDto = {
+        title: "Test Capsule",
+        content: "Test Content",
+        targetMinBpm: 60,
+        targetMaxBpm: 80,
+      }
+
+      const userId = "user123"
+
+      const capsule = {
+        id: "capsule123",
+        ...createDto,
+        userId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      mockHeartbeatCapsuleService.create.mockResolvedValue(capsule)
+
+      const result = await controller.create(createDto, { user: { id: userId } })
+
+      expect(service.create).toHaveBeenCalledWith(createDto, userId)
+      expect(result).toEqual({
+        id: capsule.id,
+        title: capsule.title,
+        isLocked: true,
+        targetMinBpm: capsule.targetMinBpm,
+        targetMaxBpm: capsule.targetMaxBpm,
+        createdAt: capsule.createdAt,
+        updatedAt: capsule.updatedAt,
+      })
+    })
+  })
+
+  describe("unlockCapsule", () => {
+    it("should try to unlock a capsule with BPM", async () => {
+      const submitBpmDto: SubmitBpmDto = {
+        bpm: 70,
+      }
+
+      const userId = "user123"
+
+      const viewDto: ViewHeartbeatCapsuleDto = {
+        id: "capsule123",
+        title: "Test Capsule",
+        content: "Secret Content",
+        isLocked: false,
+        targetMinBpm: 60,
+        targetMaxBpm: 80,
+        submittedBpm: 70,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      mockHeartbeatCapsuleService.unlockCapsule.mockResolvedValue(viewDto)
+
+      const result = await controller.unlockCapsule("capsule123", submitBpmDto, { user: { id: userId } })
+
+      expect(service.unlockCapsule).toHaveBeenCalledWith("capsule123", submitBpmDto, userId)
+      expect(result).toEqual(viewDto)
+    })
+  })
+
+  describe("findAll", () => {
+    it("should return all heartbeat capsules for the user", async () => {
+      const userId = "user123"
+
+      const capsules = [
+        {
+          id: "capsule123",
+          title: "Test Capsule 1",
+          content: "Secret Content 1",
+          userId,
+          targetMinBpm: 60,
+          targetMaxBpm: 80,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: "capsule456",
+          title: "Test Capsule 2",
+          content: "Secret Content 2",
+          userId,
+          targetMinBpm: 70,
+          targetMaxBpm: 90,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]
+
+      mockHeartbeatCapsuleService.findAll.mockResolvedValue(capsules)
+
+      const result = await controller.findAll({ user: { id: userId } })
+
+      expect(service.findAll).toHaveBeenCalledWith(userId)
+      expect(result).toEqual([
+        {
+          id: "capsule123",
+          title: "Test Capsule 1",
+          isLocked: true,
+          targetMinBpm: 60,
+          targetMaxBpm: 80,
+          createdAt: capsules[0].createdAt,
+          updatedAt: capsules[0].updatedAt,
+        },
+        {
+          id: "capsule456",
+          title: "Test Capsule 2",
+          isLocked: true,
+          targetMinBpm: 70,
+          targetMaxBpm: 90,
+          createdAt: capsules[1].createdAt,
+          updatedAt: capsules[1].updatedAt,
+        },
+      ])
+    })
+  })
+})

--- a/apps/capsulelabs-api/src/capsules/heartbeat-capsule/test/heartbeat-capsule.service.spec.ts
+++ b/apps/capsulelabs-api/src/capsules/heartbeat-capsule/test/heartbeat-capsule.service.spec.ts
@@ -1,0 +1,235 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { HeartbeatCapsuleService } from "../heartbeat-capsule.service"
+import { HeartbeatCapsule } from "../entities/heartbeat-capsule.entity"
+import { BpmSubmission } from "../entities/bpm-submission.entity"
+import type { CreateHeartbeatCapsuleDto } from "../dto/create-heartbeat-capsule.dto"
+import type { SubmitBpmDto } from "../dto/submit-bpm.dto"
+import { NotFoundException } from "@nestjs/common"
+
+describe("HeartbeatCapsuleService", () => {
+  let service: HeartbeatCapsuleService
+  let capsuleRepository: Repository<HeartbeatCapsule>
+  let submissionRepository: Repository<BpmSubmission>
+
+  const mockCapsuleRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    find: jest.fn(),
+  }
+
+  const mockSubmissionRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HeartbeatCapsuleService,
+        {
+          provide: getRepositoryToken(HeartbeatCapsule),
+          useValue: mockCapsuleRepository,
+        },
+        {
+          provide: getRepositoryToken(BpmSubmission),
+          useValue: mockSubmissionRepository,
+        },
+      ],
+    }).compile()
+
+    service = module.get<HeartbeatCapsuleService>(HeartbeatCapsuleService)
+    capsuleRepository = module.get<Repository<HeartbeatCapsule>>(getRepositoryToken(HeartbeatCapsule))
+    submissionRepository = module.get<Repository<BpmSubmission>>(getRepositoryToken(BpmSubmission))
+  })
+
+  it("should be defined", () => {
+    expect(service).toBeDefined()
+  })
+
+  describe("create", () => {
+    it("should create a new heartbeat capsule", async () => {
+      const createDto: CreateHeartbeatCapsuleDto = {
+        title: "Test Capsule",
+        content: "Test Content",
+        targetMinBpm: 60,
+        targetMaxBpm: 80,
+      }
+
+      const userId = "user123"
+
+      const capsule = {
+        id: "capsule123",
+        ...createDto,
+        userId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      mockCapsuleRepository.create.mockReturnValue(capsule)
+      mockCapsuleRepository.save.mockResolvedValue(capsule)
+
+      const result = await service.create(createDto, userId)
+
+      expect(mockCapsuleRepository.create).toHaveBeenCalledWith({
+        ...createDto,
+        userId,
+      })
+      expect(mockCapsuleRepository.save).toHaveBeenCalledWith(capsule)
+      expect(result).toEqual(capsule)
+    })
+
+    it("should throw an error if min BPM is greater than max BPM", async () => {
+      const createDto: CreateHeartbeatCapsuleDto = {
+        title: "Test Capsule",
+        content: "Test Content",
+        targetMinBpm: 90,
+        targetMaxBpm: 80,
+      }
+
+      const userId = "user123"
+
+      await expect(service.create(createDto, userId)).rejects.toThrow(
+        "Minimum BPM must be less than or equal to maximum BPM",
+      )
+    })
+  })
+
+  describe("unlockCapsule", () => {
+    it("should unlock capsule when BPM is within range", async () => {
+      const capsule = {
+        id: "capsule123",
+        title: "Test Capsule",
+        content: "Secret Content",
+        userId: "user123",
+        targetMinBpm: 60,
+        targetMaxBpm: 80,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      const submitBpmDto: SubmitBpmDto = {
+        bpm: 70,
+      }
+
+      mockCapsuleRepository.findOne.mockResolvedValue(capsule)
+      mockSubmissionRepository.create.mockReturnValue({
+        capsuleId: capsule.id,
+        userId: capsule.userId,
+        bpm: submitBpmDto.bpm,
+        successful: true,
+      })
+      mockSubmissionRepository.save.mockResolvedValue({})
+
+      const result = await service.unlockCapsule("capsule123", submitBpmDto, "user123")
+
+      expect(result.isLocked).toBe(false)
+      expect(result.content).toBe("Secret Content")
+      expect(result.submittedBpm).toBe(70)
+      expect(mockSubmissionRepository.create).toHaveBeenCalledWith({
+        capsuleId: capsule.id,
+        userId: capsule.userId,
+        bpm: submitBpmDto.bpm,
+        successful: true,
+      })
+    })
+
+    it("should keep capsule locked when BPM is below range", async () => {
+      const capsule = {
+        id: "capsule123",
+        title: "Test Capsule",
+        content: "Secret Content",
+        userId: "user123",
+        targetMinBpm: 60,
+        targetMaxBpm: 80,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      const submitBpmDto: SubmitBpmDto = {
+        bpm: 50,
+      }
+
+      mockCapsuleRepository.findOne.mockResolvedValue(capsule)
+      mockSubmissionRepository.create.mockReturnValue({
+        capsuleId: capsule.id,
+        userId: capsule.userId,
+        bpm: submitBpmDto.bpm,
+        successful: false,
+      })
+      mockSubmissionRepository.save.mockResolvedValue({})
+
+      const result = await service.unlockCapsule("capsule123", submitBpmDto, "user123")
+
+      expect(result.isLocked).toBe(true)
+      expect(result.content).toBeUndefined()
+      expect(result.submittedBpm).toBe(50)
+      expect(mockSubmissionRepository.create).toHaveBeenCalledWith({
+        capsuleId: capsule.id,
+        userId: capsule.userId,
+        bpm: submitBpmDto.bpm,
+        successful: false,
+      })
+    })
+
+    it("should keep capsule locked when BPM is above range", async () => {
+      const capsule = {
+        id: "capsule123",
+        title: "Test Capsule",
+        content: "Secret Content",
+        userId: "user123",
+        targetMinBpm: 60,
+        targetMaxBpm: 80,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      const submitBpmDto: SubmitBpmDto = {
+        bpm: 90,
+      }
+
+      mockCapsuleRepository.findOne.mockResolvedValue(capsule)
+      mockSubmissionRepository.create.mockReturnValue({
+        capsuleId: capsule.id,
+        userId: capsule.userId,
+        bpm: submitBpmDto.bpm,
+        successful: false,
+      })
+      mockSubmissionRepository.save.mockResolvedValue({})
+
+      const result = await service.unlockCapsule("capsule123", submitBpmDto, "user123")
+
+      expect(result.isLocked).toBe(true)
+      expect(result.content).toBeUndefined()
+      expect(result.submittedBpm).toBe(90)
+    })
+
+    it("should throw an error if capsule not found", async () => {
+      mockCapsuleRepository.findOne.mockResolvedValue(null)
+
+      await expect(service.unlockCapsule("nonexistent", { bpm: 70 }, "user123")).rejects.toThrow(NotFoundException)
+    })
+
+    it("should throw an error if user doesn't own the capsule", async () => {
+      const capsule = {
+        id: "capsule123",
+        title: "Test Capsule",
+        content: "Secret Content",
+        userId: "user123",
+        targetMinBpm: 60,
+        targetMaxBpm: 80,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      mockCapsuleRepository.findOne.mockResolvedValue(capsule)
+
+      await expect(service.unlockCapsule("capsule123", { bpm: 70 }, "different-user")).rejects.toThrow(
+        "You don't have permission to access this capsule",
+      )
+    })
+  })
+})

--- a/apps/capsulelabs-api/src/capsules/location-lock-capsule/common/filters/http-exception.filter.ts
+++ b/apps/capsulelabs-api/src/capsules/location-lock-capsule/common/filters/http-exception.filter.ts
@@ -1,0 +1,45 @@
+import { type ExceptionFilter, Catch, type ArgumentsHost, HttpException, HttpStatus, Logger } from "@nestjs/common"
+import type { Request, Response } from "express"
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(HttpExceptionFilter.name)
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp()
+    const response = ctx.getResponse<Response>()
+    const request = ctx.getRequest<Request>()
+
+    let status: number
+    let message: string | object
+
+    if (exception instanceof HttpException) {
+      status = exception.getStatus()
+      const exceptionResponse = exception.getResponse()
+      message = typeof exceptionResponse === "string" ? exceptionResponse : exceptionResponse
+    } else {
+      status = HttpStatus.INTERNAL_SERVER_ERROR
+      message = "Internal server error"
+
+      // Log unexpected errors
+      this.logger.error(`Unexpected error: ${exception}`, exception instanceof Error ? exception.stack : undefined)
+    }
+
+    const errorResponse = {
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+      method: request.method,
+      message,
+    }
+
+    // Log client errors (4xx) as warnings, server errors (5xx) as errors
+    if (status >= 500) {
+      this.logger.error(`${request.method} ${request.url}`, JSON.stringify(errorResponse))
+    } else if (status >= 400) {
+      this.logger.warn(`${request.method} ${request.url}`, JSON.stringify(errorResponse))
+    }
+
+    response.status(status).json(errorResponse)
+  }
+}

--- a/apps/capsulelabs-api/src/capsules/location-lock-capsule/common/interceptors/logging.interceptor.ts
+++ b/apps/capsulelabs-api/src/capsules/location-lock-capsule/common/interceptors/logging.interceptor.ts
@@ -1,0 +1,28 @@
+import { Injectable, type NestInterceptor, type ExecutionContext, type CallHandler, Logger } from "@nestjs/common"
+import type { Observable } from "rxjs"
+import { tap } from "rxjs/operators"
+import type { Request } from "express"
+
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(LoggingInterceptor.name)
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const request = context.switchToHttp().getRequest<Request>()
+    const { method, url, ip } = request
+    const userAgent = request.get("User-Agent") || ""
+    const startTime = Date.now()
+
+    this.logger.log(`${method} ${url} - ${ip} - ${userAgent}`)
+
+    return next.handle().pipe(
+      tap(() => {
+        const response = context.switchToHttp().getResponse()
+        const { statusCode } = response
+        const responseTime = Date.now() - startTime
+
+        this.logger.log(`${method} ${url} - ${statusCode} - ${responseTime}ms - ${ip}`)
+      }),
+    )
+  }
+}

--- a/apps/capsulelabs-api/src/capsules/location-lock-capsule/database/data-source.ts
+++ b/apps/capsulelabs-api/src/capsules/location-lock-capsule/database/data-source.ts
@@ -1,0 +1,16 @@
+import { DataSource } from "typeorm"
+import { LocationLockCapsule } from "../entities/location-lock-capsule.entity"
+
+export const AppDataSource = new DataSource({
+  type: "postgres",
+  host: process.env.DB_HOST || "localhost",
+  port: Number.parseInt(process.env.DB_PORT) || 5432,
+  username: process.env.DB_USERNAME || "postgres",
+  password: process.env.DB_PASSWORD || "password",
+  database: process.env.DB_NAME || "locationlock_db",
+  entities: [LocationLockCapsule],
+  migrations: ["dist/database/migrations/*.js"],
+  synchronize: false, // Always false in production
+  logging: process.env.NODE_ENV === "development",
+  ssl: process.env.NODE_ENV === "production" ? { rejectUnauthorized: false } : false,
+})

--- a/apps/capsulelabs-api/src/capsules/location-lock-capsule/database/migrations/001-create-location-lock-capsule.ts
+++ b/apps/capsulelabs-api/src/capsules/location-lock-capsule/database/migrations/001-create-location-lock-capsule.ts
@@ -1,0 +1,87 @@
+import { type MigrationInterface, type QueryRunner, Table } from "typeorm"
+
+export class CreateLocationLockCapsule1703123456789 implements MigrationInterface {
+  name = "CreateLocationLockCapsule1703123456789"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "location_lock_capsules",
+        columns: [
+          {
+            name: "id",
+            type: "uuid",
+            isPrimary: true,
+            generationStrategy: "uuid",
+            default: "gen_random_uuid()",
+          },
+          {
+            name: "title",
+            type: "varchar",
+            length: "255",
+            isNullable: false,
+          },
+          {
+            name: "content",
+            type: "text",
+            isNullable: false,
+          },
+          {
+            name: "userId",
+            type: "varchar",
+            length: "255",
+            isNullable: false,
+          },
+          {
+            name: "lockLatitude",
+            type: "decimal",
+            precision: 10,
+            scale: 8,
+            isNullable: false,
+          },
+          {
+            name: "lockLongitude",
+            type: "decimal",
+            precision: 11,
+            scale: 8,
+            isNullable: false,
+          },
+          {
+            name: "allowedRadiusMeters",
+            type: "int",
+            default: 20,
+            isNullable: false,
+          },
+          {
+            name: "createdAt",
+            type: "timestamp",
+            default: "CURRENT_TIMESTAMP",
+            isNullable: false,
+          },
+          {
+            name: "updatedAt",
+            type: "timestamp",
+            default: "CURRENT_TIMESTAMP",
+            onUpdate: "CURRENT_TIMESTAMP",
+            isNullable: false,
+          },
+        ],
+        indices: [
+          {
+            name: "IDX_LOCATION_LOCK_USER_ID",
+            columnNames: ["userId"],
+          },
+          {
+            name: "IDX_LOCATION_LOCK_COORDINATES",
+            columnNames: ["lockLatitude", "lockLongitude"],
+          },
+        ],
+      }),
+      true,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("location_lock_capsules")
+  }
+}

--- a/apps/capsulelabs-api/src/capsules/location-lock-capsule/dto/create-location-lock-capsule.dto.ts
+++ b/apps/capsulelabs-api/src/capsules/location-lock-capsule/dto/create-location-lock-capsule.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty } from "@nestjs/swagger"
+import { IsString, IsNotEmpty, IsNumber, IsOptional, Min, Max, IsLatitude, IsLongitude } from "class-validator"
+
+export class CreateLocationLockCapsuleDto {
+  @ApiProperty({
+    description: "Title of the capsule",
+    example: "Secret Message at Central Park",
+  })
+  @IsString()
+  @IsNotEmpty()
+  title: string
+
+  @ApiProperty({
+    description: "Content of the capsule",
+    example: "Congratulations! You found the hidden treasure!",
+  })
+  @IsString()
+  @IsNotEmpty()
+  content: string
+
+  @ApiProperty({
+    description: "Latitude coordinate for the lock location",
+    example: 40.7829,
+    minimum: -90,
+    maximum: 90,
+  })
+  @IsNumber()
+  @IsLatitude()
+  lockLatitude: number
+
+  @ApiProperty({
+    description: "Longitude coordinate for the lock location",
+    example: -73.9654,
+    minimum: -180,
+    maximum: 180,
+  })
+  @IsNumber()
+  @IsLongitude()
+  lockLongitude: number
+
+  @ApiProperty({
+    description: "Allowed radius in meters for unlocking",
+    example: 20,
+    default: 20,
+    minimum: 1,
+    maximum: 1000,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(1000)
+  allowedRadiusMeters?: number = 20
+}

--- a/apps/capsulelabs-api/src/capsules/location-lock-capsule/dto/unlock-attempt.dto.ts
+++ b/apps/capsulelabs-api/src/capsules/location-lock-capsule/dto/unlock-attempt.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from "@nestjs/swagger"
+import { IsNumber, IsLatitude, IsLongitude } from "class-validator"
+
+export class UnlockAttemptDto {
+  @ApiProperty({
+    description: "Current latitude of the user",
+    example: 40.7829,
+    minimum: -90,
+    maximum: 90,
+  })
+  @IsNumber()
+  @IsLatitude()
+  currentLatitude: number
+
+  @ApiProperty({
+    description: "Current longitude of the user",
+    example: -73.9654,
+    minimum: -180,
+    maximum: 180,
+  })
+  @IsNumber()
+  @IsLongitude()
+  currentLongitude: number
+}

--- a/apps/capsulelabs-api/src/capsules/location-lock-capsule/dto/unlock-response.dto.ts
+++ b/apps/capsulelabs-api/src/capsules/location-lock-capsule/dto/unlock-response.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from "@nestjs/swagger"
+
+export class UnlockResponseDto {
+  @ApiProperty({
+    description: "Whether the unlock attempt was successful",
+    example: true,
+  })
+  success: boolean
+
+  @ApiProperty({
+    description: "Message describing the result",
+    example: "Capsule unlocked successfully!",
+  })
+  message: string
+
+  @ApiProperty({
+    description: "Distance from the lock location in meters",
+    example: 15.5,
+  })
+  distanceMeters: number
+
+  @ApiProperty({
+    description: "Content of the capsule (only if unlocked)",
+    example: "Congratulations! You found the hidden treasure!",
+    required: false,
+  })
+  content?: string
+
+  @ApiProperty({
+    description: "Title of the capsule (only if unlocked)",
+    example: "Secret Message at Central Park",
+    required: false,
+  })
+  title?: string
+}

--- a/apps/capsulelabs-api/src/capsules/location-lock-capsule/entities/location-lock-capsule.entity.ts
+++ b/apps/capsulelabs-api/src/capsules/location-lock-capsule/entities/location-lock-capsule.entity.ts
@@ -1,0 +1,67 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from "typeorm"
+import { ApiProperty } from "@nestjs/swagger"
+
+@Entity("location_lock_capsules")
+export class LocationLockCapsule {
+  @ApiProperty({
+    description: "Unique identifier for the capsule",
+    example: "123e4567-e89b-12d3-a456-426614174000",
+  })
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @ApiProperty({
+    description: "Title of the capsule",
+    example: "Secret Message at Central Park",
+  })
+  @Column({ type: "varchar", length: 255 })
+  title: string
+
+  @ApiProperty({
+    description: "Content of the capsule (only accessible when unlocked)",
+    example: "Congratulations! You found the hidden treasure!",
+  })
+  @Column({ type: "text" })
+  content: string
+
+  @ApiProperty({
+    description: "User ID who created the capsule",
+    example: "user123",
+  })
+  @Column({ type: "varchar", length: 255 })
+  userId: string
+
+  @ApiProperty({
+    description: "Latitude coordinate for the lock location",
+    example: 40.7829,
+  })
+  @Column({ type: "decimal", precision: 10, scale: 8 })
+  lockLatitude: number
+
+  @ApiProperty({
+    description: "Longitude coordinate for the lock location",
+    example: -73.9654,
+  })
+  @Column({ type: "decimal", precision: 11, scale: 8 })
+  lockLongitude: number
+
+  @ApiProperty({
+    description: "Allowed radius in meters for unlocking",
+    example: 20,
+    default: 20,
+  })
+  @Column({ type: "int", default: 20 })
+  allowedRadiusMeters: number
+
+  @ApiProperty({
+    description: "When the capsule was created",
+  })
+  @CreateDateColumn()
+  createdAt: Date
+
+  @ApiProperty({
+    description: "When the capsule was last updated",
+  })
+  @UpdateDateColumn()
+  updatedAt: Date
+}

--- a/apps/capsulelabs-api/src/capsules/location-lock-capsule/health/health.controller.ts
+++ b/apps/capsulelabs-api/src/capsules/location-lock-capsule/health/health.controller.ts
@@ -1,0 +1,83 @@
+import { Controller, Get } from "@nestjs/common"
+import { ApiTags, ApiOperation, ApiResponse } from "@nestjs/swagger"
+import {
+  type HealthCheckService,
+  HealthCheck,
+  type TypeOrmHealthIndicator,
+  type MemoryHealthIndicator,
+  type DiskHealthIndicator,
+} from "@nestjs/terminus"
+
+@ApiTags("Health")
+@Controller("health")
+export class HealthController {
+  constructor(
+    private health: HealthCheckService,
+    private db: TypeOrmHealthIndicator,
+    private memory: MemoryHealthIndicator,
+    private disk: DiskHealthIndicator,
+  ) {}
+
+  @Get()
+  @ApiOperation({
+    summary: "Health check",
+    description: "Check the health status of the application and its dependencies",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Health check successful",
+    schema: {
+      example: {
+        status: "ok",
+        info: {
+          database: { status: "up" },
+          memory_heap: { status: "up" },
+          memory_rss: { status: "up" },
+          storage: { status: "up" },
+        },
+        error: {},
+        details: {
+          database: { status: "up" },
+          memory_heap: { status: "up" },
+          memory_rss: { status: "up" },
+          storage: { status: "up" },
+        },
+      },
+    },
+  })
+  @HealthCheck()
+  check() {
+    return this.health.check([
+      () => this.db.pingCheck("database"),
+      () => this.memory.checkHeap("memory_heap", 150 * 1024 * 1024),
+      () => this.memory.checkRSS("memory_rss", 150 * 1024 * 1024),
+      () => this.disk.checkStorage("storage", { path: "/", thresholdPercent: 0.9 }),
+    ])
+  }
+
+  @Get("ready")
+  @ApiOperation({
+    summary: "Readiness check",
+    description: "Check if the application is ready to serve requests",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Application is ready",
+  })
+  ready() {
+    return { status: "ready", timestamp: new Date().toISOString() }
+  }
+
+  @Get("live")
+  @ApiOperation({
+    summary: "Liveness check",
+    description: "Check if the application is alive",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Application is alive",
+  })
+  live() {
+    return { status: "alive", timestamp: new Date().toISOString() }
+  }
+}

--- a/apps/capsulelabs-api/src/capsules/location-lock-capsule/health/health.module.ts
+++ b/apps/capsulelabs-api/src/capsules/location-lock-capsule/health/health.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common"
+import { TerminusModule } from "@nestjs/terminus"
+import { HealthController } from "./health.controller"
+
+@Module({
+  imports: [TerminusModule],
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/apps/capsulelabs-api/src/capsules/location-lock-capsule/location-lock.controller.ts
+++ b/apps/capsulelabs-api/src/capsules/location-lock-capsule/location-lock.controller.ts
@@ -1,0 +1,146 @@
+import { Controller, Get, Post, Body, Param, Query, ParseUUIDPipe } from "@nestjs/common"
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from "@nestjs/swagger"
+import type { LocationLockService } from "./location-lock.service"
+import type { CreateLocationLockCapsuleDto } from "./dto/create-location-lock-capsule.dto"
+import type { UnlockAttemptDto } from "./dto/unlock-attempt.dto"
+import { UnlockResponseDto } from "./dto/unlock-response.dto"
+import { LocationLockCapsule } from "./entities/location-lock-capsule.entity"
+
+@ApiTags("Location Lock Capsules")
+@Controller("capsules/location-lock")
+export class LocationLockController {
+  constructor(private readonly locationLockService: LocationLockService) {}
+
+  @Post()
+  @ApiOperation({
+    summary: "Create a new location-locked capsule",
+    description: "Creates a capsule that can only be unlocked at specific GPS coordinates",
+  })
+  @ApiResponse({
+    status: 201,
+    description: "Capsule created successfully",
+    type: LocationLockCapsule,
+  })
+  @ApiResponse({
+    status: 400,
+    description: "Invalid input data",
+  })
+  async create(
+    @Body() createLocationLockCapsuleDto: CreateLocationLockCapsuleDto,
+    @Query('userId') userId: string = 'default-user', // In real app, get from JWT token
+  ): Promise<LocationLockCapsule> {
+    return await this.locationLockService.create(createLocationLockCapsuleDto, userId)
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: 'Get all location-locked capsules',
+    description: 'Retrieves all capsules (without content for security)',
+  })
+  @ApiQuery({
+    name: 'userId',
+    required: false,
+    description: 'Filter by user ID',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of capsules retrieved successfully',
+    type: [LocationLockCapsule],
+  })
+  async findAll(
+    @Query('userId') userId?: string,
+  ): Promise<LocationLockCapsule[]> {
+    return await this.locationLockService.findAll(userId);
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Get a specific capsule by ID',
+    description: 'Retrieves capsule metadata (without content for security)',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Capsule UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Capsule retrieved successfully',
+    type: LocationLockCapsule,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Capsule not found',
+  })
+  async findOne(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<LocationLockCapsule> {
+    return await this.locationLockService.findOne(id);
+  }
+
+  @Post(":id/unlock")
+  @ApiOperation({
+    summary: "Attempt to unlock a capsule",
+    description: `Submit your current GPS coordinates to unlock a capsule. 
+    The server validates your location against the capsule's lock coordinates using the Haversine formula.
+    If you're within the allowed radius, you'll receive the capsule content.`,
+  })
+  @ApiParam({
+    name: "id",
+    description: "Capsule UUID to unlock",
+    example: "123e4567-e89b-12d3-a456-426614174000",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Unlock attempt processed",
+    type: UnlockResponseDto,
+    examples: {
+      success: {
+        summary: "Successful unlock",
+        value: {
+          success: true,
+          message: "Capsule unlocked successfully!",
+          distanceMeters: 15.5,
+          content: "Congratulations! You found the hidden treasure!",
+          title: "Secret Message at Central Park",
+        },
+      },
+      failure: {
+        summary: "Failed unlock (too far)",
+        value: {
+          success: false,
+          message: "You are 150m away. Get within 20m to unlock.",
+          distanceMeters: 150.2,
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: "Capsule not found",
+  })
+  @ApiResponse({
+    status: 400,
+    description: "Invalid GPS coordinates",
+  })
+  async unlock(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() unlockAttemptDto: UnlockAttemptDto,
+  ): Promise<UnlockResponseDto> {
+    return await this.locationLockService.attemptUnlock(id, unlockAttemptDto)
+  }
+
+  @Post("seed")
+  @ApiOperation({
+    summary: "Seed test data",
+    description: "Creates test capsules at Times Square and Central Park for testing",
+  })
+  @ApiResponse({
+    status: 201,
+    description: "Test data seeded successfully",
+  })
+  async seedTestData(): Promise<{ message: string }> {
+    await this.locationLockService.seedTestData()
+    return { message: "Test capsules seeded successfully!" }
+  }
+}

--- a/apps/capsulelabs-api/src/capsules/location-lock-capsule/location-lock.module.ts
+++ b/apps/capsulelabs-api/src/capsules/location-lock-capsule/location-lock.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { LocationLockController } from "./location-lock.controller"
+import { LocationLockService } from "./location-lock.service"
+import { LocationLockCapsule } from "./entities/location-lock-capsule.entity"
+
+@Module({
+  imports: [TypeOrmModule.forFeature([LocationLockCapsule])],
+  controllers: [LocationLockController],
+  providers: [LocationLockService],
+  exports: [LocationLockService],
+})
+export class LocationLockModule {}

--- a/apps/capsulelabs-api/src/capsules/location-lock-capsule/location-lock.service.ts
+++ b/apps/capsulelabs-api/src/capsules/location-lock-capsule/location-lock.service.ts
@@ -1,0 +1,210 @@
+import { Injectable, NotFoundException, Logger } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import type { LocationLockCapsule } from "./entities/location-lock-capsule.entity"
+import type { CreateLocationLockCapsuleDto } from "./dto/create-location-lock-capsule.dto"
+import type { UnlockAttemptDto } from "./dto/unlock-attempt.dto"
+import type { UnlockResponseDto } from "./dto/unlock-response.dto"
+
+@Injectable()
+export class LocationLockService {
+  private readonly logger = new Logger(LocationLockService.name)
+
+  constructor(private readonly capsuleRepository: Repository<LocationLockCapsule>) {}
+
+  async create(createDto: CreateLocationLockCapsuleDto, userId: string): Promise<LocationLockCapsule> {
+    this.logger.log(`Creating new capsule for user: ${userId}`)
+
+    const capsule = this.capsuleRepository.create({
+      ...createDto,
+      userId,
+    })
+
+    const savedCapsule = await this.capsuleRepository.save(capsule)
+
+    this.logger.log(`Capsule created successfully: ${savedCapsule.id}`)
+    return savedCapsule
+  }
+
+  async findAll(userId?: string): Promise<LocationLockCapsule[]> {
+    const query = this.capsuleRepository.createQueryBuilder("capsule")
+
+    if (userId) {
+      query.where("capsule.userId = :userId", { userId })
+    }
+
+    // Don't return content in list view for security
+    query.select([
+      "capsule.id",
+      "capsule.title",
+      "capsule.userId",
+      "capsule.lockLatitude",
+      "capsule.lockLongitude",
+      "capsule.allowedRadiusMeters",
+      "capsule.createdAt",
+      "capsule.updatedAt",
+    ])
+
+    const capsules = await query.getMany()
+    this.logger.log(`Retrieved ${capsules.length} capsules${userId ? ` for user: ${userId}` : ""}`)
+
+    return capsules
+  }
+
+  async findOne(id: string): Promise<LocationLockCapsule> {
+    const capsule = await this.capsuleRepository.findOne({
+      where: { id },
+      select: [
+        "id",
+        "title",
+        "userId",
+        "lockLatitude",
+        "lockLongitude",
+        "allowedRadiusMeters",
+        "createdAt",
+        "updatedAt",
+      ],
+    })
+
+    if (!capsule) {
+      this.logger.warn(`Capsule not found: ${id}`)
+      throw new NotFoundException("Capsule not found")
+    }
+
+    return capsule
+  }
+
+  async attemptUnlock(id: string, unlockDto: UnlockAttemptDto): Promise<UnlockResponseDto> {
+    this.logger.log(`Unlock attempt for capsule: ${id}`)
+
+    const capsule = await this.capsuleRepository.findOne({
+      where: { id },
+    })
+
+    if (!capsule) {
+      this.logger.warn(`Unlock attempt failed - capsule not found: ${id}`)
+      throw new NotFoundException("Capsule not found")
+    }
+
+    const distance = this.calculateHaversineDistance(
+      capsule.lockLatitude,
+      capsule.lockLongitude,
+      unlockDto.currentLatitude,
+      unlockDto.currentLongitude,
+    )
+
+    const isWithinRange = distance <= capsule.allowedRadiusMeters
+
+    this.logger.log(
+      `Unlock attempt - Distance: ${distance.toFixed(2)}m, Required: ${capsule.allowedRadiusMeters}m, Success: ${isWithinRange}`,
+    )
+
+    const response: UnlockResponseDto = {
+      success: isWithinRange,
+      message: isWithinRange
+        ? "Capsule unlocked successfully!"
+        : `You are ${Math.round(distance)}m away. Get within ${capsule.allowedRadiusMeters}m to unlock.`,
+      distanceMeters: Math.round(distance * 100) / 100, // Round to 2 decimal places
+    }
+
+    if (isWithinRange) {
+      response.content = capsule.content
+      response.title = capsule.title
+      this.logger.log(`Capsule unlocked successfully: ${id}`)
+    }
+
+    return response
+  }
+
+  /**
+   * Calculate the distance between two points using the Haversine formula
+   * @param lat1 Latitude of first point
+   * @param lon1 Longitude of first point
+   * @param lat2 Latitude of second point
+   * @param lon2 Longitude of second point
+   * @returns Distance in meters
+   */
+  private calculateHaversineDistance(lat1: number, lon1: number, lat2: number, lon2: number): number {
+    const R = 6371000 // Earth's radius in meters
+    const φ1 = (lat1 * Math.PI) / 180
+    const φ2 = (lat2 * Math.PI) / 180
+    const Δφ = ((lat2 - lat1) * Math.PI) / 180
+    const Δλ = ((lon2 - lon1) * Math.PI) / 180
+
+    const a = Math.sin(Δφ / 2) * Math.sin(Δφ / 2) + Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) * Math.sin(Δλ / 2)
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+
+    return R * c
+  }
+
+  async seedTestData(): Promise<void> {
+    this.logger.log("Seeding test data...")
+
+    // Check if test data already exists
+    const existingCapsules = await this.capsuleRepository.count()
+    if (existingCapsules > 0) {
+      this.logger.log("Test data already exists, skipping seed")
+      return
+    }
+
+    // Times Square coordinates
+    const timesSquareCapsule = {
+      title: "Times Square Secret",
+      content: "Welcome to the crossroads of the world! You found the Times Square capsule! 🗽",
+      userId: "test-user",
+      lockLatitude: 40.758,
+      lockLongitude: -73.9855,
+      allowedRadiusMeters: 50,
+    }
+
+    // Central Park coordinates
+    const centralParkCapsule = {
+      title: "Central Park Treasure",
+      content: "Nature in the heart of the city! You discovered the Central Park secret! 🌳",
+      userId: "test-user",
+      lockLatitude: 40.7829,
+      lockLongitude: -73.9654,
+      allowedRadiusMeters: 30,
+    }
+
+    // Brooklyn Bridge coordinates
+    const brooklynBridgeCapsule = {
+      title: "Brooklyn Bridge Mystery",
+      content: "A historic crossing! You found the Brooklyn Bridge capsule! 🌉",
+      userId: "test-user",
+      lockLatitude: 40.7061,
+      lockLongitude: -73.9969,
+      allowedRadiusMeters: 40,
+    }
+
+    await this.capsuleRepository.save([timesSquareCapsule, centralParkCapsule, brooklynBridgeCapsule])
+
+    this.logger.log("Test capsules seeded successfully!")
+  }
+
+  async getStats(): Promise<{
+    totalCapsules: number
+    capsulesPerUser: Record<string, number>
+    averageRadius: number
+  }> {
+    const capsules = await this.capsuleRepository.find()
+
+    const capsulesPerUser = capsules.reduce(
+      (acc, capsule) => {
+        acc[capsule.userId] = (acc[capsule.userId] || 0) + 1
+        return acc
+      },
+      {} as Record<string, number>,
+    )
+
+    const averageRadius =
+      capsules.length > 0
+        ? capsules.reduce((sum, capsule) => sum + capsule.allowedRadiusMeters, 0) / capsules.length
+        : 0
+
+    return {
+      totalCapsules: capsules.length,
+      capsulesPerUser,
+      averageRadius: Math.round(averageRadius * 100) / 100,
+    }
+  }
+}


### PR DESCRIPTION
### Heartbeat Capsule NestJS Feature


### Pull Request: Implement Heartbeat Capsule Feature

## Description

This PR implements the Heartbeat Capsule feature, which allows content to be accessible only when the user's heart rate falls within a specified BPM (beats per minute) range. This feature can be used to create experiences that are only available during specific physiological states like relaxation, exercise, or meditation.

closes #22 

## Features

- Capsules have a target heart rate range (min and max BPM)
- Content unlocks only when submitted BPM falls within the specified range
- Logs all BPM submissions for analytics and history tracking
- Comprehensive test coverage for edge cases and invalid BPMs
- Seed data with different BPM ranges for testing


## Implementation Details

### New Files

```plaintext
src/modules/heartbeat-capsule/
├── heartbeat-capsule.module.ts
├── heartbeat-capsule.controller.ts
├── heartbeat-capsule.service.ts
├── entities/
│   ├── heartbeat-capsule.entity.ts
│   └── bpm-submission.entity.ts
├── dto/
│   ├── create-heartbeat-capsule.dto.ts
│   ├── submit-bpm.dto.ts
│   └── view-heartbeat-capsule.dto.ts
├── test/
│   ├── heartbeat-capsule.service.spec.ts
│   └── heartbeat-capsule.controller.spec.ts
└── seed/
    └── heartbeat-capsule.seed.ts
```

### API Endpoints

- `POST /capsules/heartbeat` - Create a new heartbeat capsule
- `GET /capsules/heartbeat` - Get all user's heartbeat capsules
- `GET /capsules/heartbeat/:id` - Get a specific capsule (locked by default)
- `POST /capsules/heartbeat/:id/unlock` - Submit BPM and try to unlock a capsule
- `GET /capsules/heartbeat/:id/history` - Get BPM submission history for a capsule


## Database Schema

The feature adds two new tables:

1. `heartbeat_capsules` - Stores capsule data including target BPM range
2. `bpm_submissions` - Logs all BPM submissions with success/failure status


## Testing Instructions

1. Run the unit tests:

```shellscript
npm run test src/modules/heartbeat-capsule
```


2. Manual testing:

1. Create a capsule with a BPM range (e.g., 60-80 BPM)
2. Try unlocking with BPM below range (e.g., 50 BPM) - should remain locked
3. Try unlocking with BPM within range (e.g., 70 BPM) - should unlock
4. Try unlocking with BPM above range (e.g., 90 BPM) - should remain locked
5. Check submission history to verify all attempts are logged

## Seed Data

The PR includes seed data for testing with different BPM ranges:

- Relaxation Capsule: 55-75 BPM
- Exercise Capsule: 100-120 BPM
- Meditation Capsule: 40-60 BPM


## Code Example

Here's a sample of how to use the service:

```typescript
// Create a new capsule
const capsule = await heartbeatCapsuleService.create({
  title: "Meditation Capsule",
  content: "This content is only visible during meditation",
  targetMinBpm: 50,
  targetMaxBpm: 70
}, userId);

// Try to unlock the capsule with a BPM reading
const result = await heartbeatCapsuleService.unlockCapsule(
  capsule.id, 
  { bpm: 60 }, 
  userId
);

if (!result.isLocked) {
  console.log("Content is available:", result.content);
} else {
  console.log("Content is locked. Your BPM:", result.submittedBpm);
  console.log("Target range:", result.targetMinBpm, "-", result.targetMaxBpm);
}
```

## Future Improvements

- Integration with Apple HealthKit or Google Fit for automatic heart rate readings
- Real-time BPM monitoring using WebSockets
- Visualization of BPM history and unlock attempts
- Support for other biometric data (e.g., blood pressure, oxygen levels)


## Checklist

- Feature implementation complete
- Unit tests written and passing
- API documentation with Swagger
- Seed data for testing
- Code follows project style guidelines
- No breaking changes to existing functionality