### PR TITLE
created the dream capsule and other features

### DIFF
--- a/apps/capsulelabs-api/src/dream-capsule/controllers/dream-capsule.controller.ts
+++ b/apps/capsulelabs-api/src/dream-capsule/controllers/dream-capsule.controller.ts
@@ -1,0 +1,45 @@
+import { Controller, Get, Post, Body, Param, Query, ParseUUIDPipe, ValidationPipe } from "@nestjs/common"
+import type { DreamCapsuleService } from "../services/dream-capsule.service"
+import type { CreateDreamCapsuleDto } from "../dto/create-dream-capsule.dto"
+import type { LogDreamDto } from "../dto/log-dream.dto"
+import type { DreamCapsuleResponseDto, LogDreamResponseDto } from "../dto/dream-capsule-response.dto"
+
+// Note: You'll need to implement your own authentication guard
+// import { AuthGuard } from '@nestjs/passport';
+// import { GetUser } from '../auth/get-user.decorator';
+
+@Controller("dream-capsules")
+// @UseGuards(AuthGuard())
+export class DreamCapsuleController {
+  constructor(private readonly dreamCapsuleService: DreamCapsuleService) {}
+
+  @Post()
+  async createCapsule(
+    @Body() createCapsuleDto: CreateDreamCapsuleDto,
+  ): Promise<DreamCapsuleResponseDto> {
+    return await this.dreamCapsuleService.createCapsule(createCapsuleDto)
+  }
+
+  @Get()
+  async getUserCapsules(
+    @Query('userId') userId: string,
+  ): Promise<DreamCapsuleResponseDto[]> {
+    return await this.dreamCapsuleService.getUserCapsules(userId)
+  }
+
+  @Get(":id")
+  async getCapsuleById(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('userId') userId: string,
+  ): Promise<DreamCapsuleResponseDto> {
+    return await this.dreamCapsuleService.getCapsuleById(id, userId)
+  }
+
+  @Post("log-dream")
+  async logDream(
+    @Query('userId') userId: string,
+    @Body(ValidationPipe) logDreamDto: LogDreamDto,
+  ): Promise<LogDreamResponseDto> {
+    return await this.dreamCapsuleService.logDream(userId, logDreamDto)
+  }
+}

--- a/apps/capsulelabs-api/src/dream-capsule/controllers/dream-log.controller.ts
+++ b/apps/capsulelabs-api/src/dream-capsule/controllers/dream-log.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Param, Query, ParseUUIDPipe, ParseIntPipe } from "@nestjs/common"
+import type { DreamLogService } from "../services/dream-log.service"
+import type { DreamLog } from "../entities/dream-log.entity"
+
+// Note: You'll need to implement your own authentication guard
+// import { AuthGuard } from '@nestjs/passport';
+// import { GetUser } from '../auth/get-user.decorator';
+
+@Controller("dream-logs")
+// @UseGuards(AuthGuard())
+export class DreamLogController {
+  constructor(private readonly dreamLogService: DreamLogService) {}
+
+  @Get(":id")
+  async getDreamLogById(@Param('id') id: string, @Query('userId') userId: string): Promise<DreamLog> {
+    return await this.dreamLogService.getDreamLogById(id, userId)
+  }
+
+  @Get("user/:userId")
+  async getUserDreamLogs(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Query('limit', new ParseIntPipe({ optional: true })) limit?: number,
+  ): Promise<DreamLog[]> {
+    return await this.dreamLogService.getUserDreamLogs(userId, limit)
+  }
+
+  @Get("today/:userId")
+  async getTodaysDreamLog(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Query('timezone') timezone?: string,
+  ): Promise<DreamLog | null> {
+    return await this.dreamLogService.getTodaysDreamLog(userId, timezone)
+  }
+}

--- a/apps/capsulelabs-api/src/dream-capsule/cron/dream-capsule-maintenance.cron.ts
+++ b/apps/capsulelabs-api/src/dream-capsule/cron/dream-capsule-maintenance.cron.ts
@@ -1,0 +1,98 @@
+import { Injectable } from "@nestjs/common"
+import { Cron, CronExpression } from "@nestjs/schedule"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { DreamCapsule, DreamCapsuleStatus } from "../entities/dream-capsule.entity"
+import { DreamCapsuleInteractionLog, DreamInteractionType } from "../entities/dream-capsule-interaction-log.entity"
+import { Logger } from "@nestjs/common"
+import { LessThan } from "typeorm"
+
+@Injectable()
+export class DreamCapsuleMaintenance {
+  private readonly logger = new Logger(DreamCapsuleMaintenance.name);
+
+  constructor(
+    @InjectRepository(DreamCapsule)
+    private dreamCapsuleRepository: Repository<DreamCapsule>,
+    @InjectRepository(DreamCapsuleInteractionLog)
+    private interactionLogRepository: Repository<DreamCapsuleInteractionLog>,
+  ) {}
+
+  /**
+   * Check for expired capsules daily
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async checkExpiredCapsules() {
+    this.logger.log("Checking for expired dream capsules")
+
+    try {
+      const now = new Date()
+
+      // Find capsules that have expired
+      const expiredCapsules = await this.dreamCapsuleRepository.find({
+        where: {
+          status: DreamCapsuleStatus.LOCKED,
+          expiresAt: LessThan(now),
+        },
+      })
+
+      this.logger.log(`Found ${expiredCapsules.length} expired dream capsules`)
+
+      // Update status and log expiration
+      for (const capsule of expiredCapsules) {
+        capsule.status = DreamCapsuleStatus.EXPIRED
+        await this.dreamCapsuleRepository.save(capsule)
+
+        // Log expiration
+        await this.logInteraction(capsule.userId, capsule.id, DreamInteractionType.EXPIRED, {
+          expiredAt: now,
+          originalExpiryDate: capsule.expiresAt,
+        })
+
+        this.logger.log(`Marked capsule ${capsule.id} as expired`)
+      }
+    } catch (error) {
+      this.logger.error("Error checking expired dream capsules:", error.stack)
+    }
+  }
+
+  /**
+   * Clean up old interaction logs to prevent database bloat
+   * Runs monthly to remove logs older than 1 year
+   */
+  @Cron(CronExpression.EVERY_1ST_DAY_OF_MONTH_AT_MIDNIGHT)
+  async cleanupOldLogs() {
+    this.logger.log("Starting monthly dream capsule log cleanup")
+
+    try {
+      const oneYearAgo = new Date()
+      oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1)
+
+      const result = await this.interactionLogRepository
+        .createQueryBuilder()
+        .delete()
+        .where("timestamp < :date", { date: oneYearAgo })
+        .execute()
+
+      this.logger.log(`Cleaned up ${result.affected} old dream capsule interaction logs`)
+    } catch (error) {
+      this.logger.error("Error during dream capsule log cleanup:", error.stack)
+    }
+  }
+
+  private async logInteraction(
+    userId: string,
+    capsuleId: string,
+    type: DreamInteractionType,
+    metadata?: Record<string, any>,
+  ): Promise<void> {
+    const log = this.interactionLogRepository.create({
+      userId,
+      capsuleId,
+      type,
+      metadata,
+    })
+
+    await this.interactionLogRepository.save(log)
+  }
+}

--- a/apps/capsulelabs-api/src/dream-capsule/dream-capsule.module.ts
+++ b/apps/capsulelabs-api/src/dream-capsule/dream-capsule.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { DreamCapsuleController } from "./controllers/dream-capsule.controller"
+import { DreamLogController } from "./controllers/dream-log.controller"
+import { DreamCapsuleService } from "./services/dream-capsule.service"
+import { DreamLogService } from "./services/dream-log.service"
+import { DreamValidationService } from "./services/dream-validation.service"
+import { DreamCapsule } from "./entities/dream-capsule.entity"
+import { DreamLog } from "./entities/dream-log.entity"
+import { DreamCapsuleInteractionLog } from "./entities/dream-capsule-interaction-log.entity"
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DreamCapsule, DreamLog, DreamCapsuleInteractionLog])],
+  controllers: [DreamCapsuleController, DreamLogController],
+  providers: [DreamCapsuleService, DreamLogService, DreamValidationService],
+  exports: [DreamCapsuleService, DreamLogService],
+})
+export class DreamCapsuleModule {}

--- a/apps/capsulelabs-api/src/dream-capsule/dto/create-dream-capsule.dto.ts
+++ b/apps/capsulelabs-api/src/dream-capsule/dto/create-dream-capsule.dto.ts
@@ -1,0 +1,42 @@
+import { IsString, IsOptional, IsEnum, IsDateString, IsObject, IsInt, Min, Max } from "class-validator"
+import { DreamCapsuleType } from "../entities/dream-capsule.entity"
+
+export class CreateDreamCapsuleDto {
+  @IsString()
+  title: string
+
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @IsObject()
+  content: Record<string, any>
+
+  @IsEnum(DreamCapsuleType)
+  type: DreamCapsuleType
+
+  @IsString()
+  userId: string
+
+  @IsOptional()
+  @IsInt()
+  @Min(10)
+  @Max(1000)
+  minimumWordCount?: number
+
+  @IsOptional()
+  @IsString()
+  cutoffTime?: string
+
+  @IsOptional()
+  @IsString()
+  timezone?: string
+
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/dream-capsule/dto/dream-capsule-response.dto.ts
+++ b/apps/capsulelabs-api/src/dream-capsule/dto/dream-capsule-response.dto.ts
@@ -1,0 +1,45 @@
+import type { DreamCapsuleStatus, DreamCapsuleType } from "../entities/dream-capsule.entity"
+import type { DreamClarity, DreamEmotion } from "../entities/dream-log.entity"
+
+export class DreamLogResponseDto {
+  id: string
+  content: string
+  wordCount: number
+  title?: string
+  clarity?: DreamClarity
+  emotion?: DreamEmotion
+  isLucid: boolean
+  timezone: string
+  isBeforeCutoff: boolean
+  createdAt: Date
+  logDate: Date
+}
+
+export class DreamCapsuleResponseDto {
+  id: string
+  title: string
+  description?: string
+  content?: Record<string, any>
+  type: DreamCapsuleType
+  status: DreamCapsuleStatus
+  userId: string
+  minimumWordCount: number
+  cutoffTime: string
+  timezone: string
+  unlockedAt?: Date
+  expiresAt?: Date
+  unlockedByDreamLogId?: string
+  metadata?: Record<string, any>
+  createdAt: Date
+  updatedAt: Date
+  canUnlockToday: boolean
+  todaysDreamLog?: DreamLogResponseDto
+}
+
+export class LogDreamResponseDto {
+  success: boolean
+  message: string
+  dreamLog: DreamLogResponseDto
+  capsuleUnlocked: boolean
+  unlockedCapsule?: DreamCapsuleResponseDto
+}

--- a/apps/capsulelabs-api/src/dream-capsule/dto/log-dream.dto.ts
+++ b/apps/capsulelabs-api/src/dream-capsule/dto/log-dream.dto.ts
@@ -1,0 +1,31 @@
+import { IsString, IsOptional, IsEnum, IsBoolean, IsObject } from "class-validator"
+import { DreamClarity, DreamEmotion } from "../entities/dream-log.entity"
+
+export class LogDreamDto {
+  @IsString()
+  content: string
+
+  @IsOptional()
+  @IsString()
+  title?: string
+
+  @IsOptional()
+  @IsEnum(DreamClarity)
+  clarity?: DreamClarity
+
+  @IsOptional()
+  @IsEnum(DreamEmotion)
+  emotion?: DreamEmotion
+
+  @IsOptional()
+  @IsBoolean()
+  isLucid?: boolean
+
+  @IsOptional()
+  @IsString()
+  timezone?: string
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/dream-capsule/entities/dream-capsule-interaction-log.entity.ts
+++ b/apps/capsulelabs-api/src/dream-capsule/entities/dream-capsule-interaction-log.entity.ts
@@ -1,0 +1,55 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, JoinColumn } from "typeorm"
+import { DreamCapsule } from "./dream-capsule.entity"
+
+export enum DreamInteractionType {
+  CREATED = "created",
+  VIEWED = "viewed",
+  DREAM_LOGGED = "dream_logged",
+  DREAM_VALIDATED = "dream_validated",
+  DREAM_REJECTED = "dream_rejected",
+  UNLOCKED = "unlocked",
+  EXPIRED = "expired",
+}
+
+@Entity("dream_capsule_interaction_logs")
+export class DreamCapsuleInteractionLog {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "uuid" })
+  capsuleId: string
+
+  @Column({
+    type: "enum",
+    enum: DreamInteractionType,
+  })
+  type: DreamInteractionType
+
+  @Column({ type: "uuid", nullable: true })
+  dreamLogId: string
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  userAgent: string
+
+  @Column({ type: "inet", nullable: true })
+  ipAddress: string
+
+  @CreateDateColumn()
+  timestamp: Date
+
+  @ManyToOne(
+    () => DreamCapsule,
+    (capsule) => capsule.interactionLogs,
+    {
+      onDelete: "CASCADE",
+    },
+  )
+  @JoinColumn({ name: "capsuleId" })
+  capsule: DreamCapsule
+}

--- a/apps/capsulelabs-api/src/dream-capsule/entities/dream-capsule.entity.ts
+++ b/apps/capsulelabs-api/src/dream-capsule/entities/dream-capsule.entity.ts
@@ -1,0 +1,81 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from "typeorm"
+import { DreamCapsuleInteractionLog } from "./dream-capsule-interaction-log.entity"
+
+export enum DreamCapsuleStatus {
+  LOCKED = "locked",
+  UNLOCKED = "unlocked",
+  EXPIRED = "expired",
+}
+
+export enum DreamCapsuleType {
+  TEXT = "text",
+  IMAGE = "image",
+  VIDEO = "video",
+  AUDIO = "audio",
+  MIXED = "mixed",
+}
+
+@Entity("dream_capsules")
+export class DreamCapsule {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "varchar", length: 255 })
+  title: string
+
+  @Column({ type: "text", nullable: true })
+  description: string
+
+  @Column({ type: "jsonb" })
+  content: Record<string, any>
+
+  @Column({
+    type: "enum",
+    enum: DreamCapsuleType,
+    default: DreamCapsuleType.TEXT,
+  })
+  type: DreamCapsuleType
+
+  @Column({
+    type: "enum",
+    enum: DreamCapsuleStatus,
+    default: DreamCapsuleStatus.LOCKED,
+  })
+  status: DreamCapsuleStatus
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "int", default: 50 })
+  minimumWordCount: number
+
+  @Column({ type: "time", default: "09:00:00" })
+  cutoffTime: string
+
+  @Column({ type: "varchar", length: 50, default: "UTC" })
+  timezone: string
+
+  @Column({ type: "timestamp", nullable: true })
+  unlockedAt: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  expiresAt: Date
+
+  @Column({ type: "uuid", nullable: true })
+  unlockedByDreamLogId: string
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+
+  @OneToMany(
+    () => DreamCapsuleInteractionLog,
+    (log) => log.capsule,
+  )
+  interactionLogs: DreamCapsuleInteractionLog[]
+}

--- a/apps/capsulelabs-api/src/dream-capsule/entities/dream-log.entity.ts
+++ b/apps/capsulelabs-api/src/dream-capsule/entities/dream-log.entity.ts
@@ -1,0 +1,74 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, Index } from "typeorm"
+
+export enum DreamClarity {
+  VIVID = "vivid",
+  CLEAR = "clear",
+  FUZZY = "fuzzy",
+  VAGUE = "vague",
+}
+
+export enum DreamEmotion {
+  HAPPY = "happy",
+  EXCITED = "excited",
+  CALM = "calm",
+  NEUTRAL = "neutral",
+  ANXIOUS = "anxious",
+  SCARED = "scared",
+  SAD = "sad",
+  ANGRY = "angry",
+}
+
+@Entity("dream_logs")
+export class DreamLog {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  @Index()
+  userId: string
+
+  @Column({ type: "text" })
+  content: string
+
+  @Column({ type: "int" })
+  wordCount: number
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  title: string
+
+  @Column({
+    type: "enum",
+    enum: DreamClarity,
+    nullable: true,
+  })
+  clarity: DreamClarity
+
+  @Column({
+    type: "enum",
+    enum: DreamEmotion,
+    nullable: true,
+  })
+  emotion: DreamEmotion
+
+  @Column({ type: "boolean", default: false })
+  isLucid: boolean
+
+  @Column({ type: "varchar", length: 50, default: "UTC" })
+  timezone: string
+
+  @Column({ type: "boolean", default: false })
+  isBeforeCutoff: boolean
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+
+  @Column({ type: "date" })
+  @Index()
+  logDate: Date
+}

--- a/apps/capsulelabs-api/src/dream-capsule/services/dream-capsule.service.ts
+++ b/apps/capsulelabs-api/src/dream-capsule/services/dream-capsule.service.ts
@@ -1,0 +1,222 @@
+import { Injectable, NotFoundException, BadRequestException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { DreamCapsule, DreamCapsuleStatus } from "../entities/dream-capsule.entity"
+import { DreamCapsuleInteractionLog, DreamInteractionType } from "../entities/dream-capsule-interaction-log.entity"
+import type { CreateDreamCapsuleDto } from "../dto/create-dream-capsule.dto"
+import type { LogDreamDto } from "../dto/log-dream.dto"
+import type {
+  DreamCapsuleResponseDto,
+  LogDreamResponseDto,
+  DreamLogResponseDto,
+} from "../dto/dream-capsule-response.dto"
+import type { DreamLogService } from "./dream-log.service"
+import type { DreamValidationService } from "./dream-validation.service"
+
+@Injectable()
+export class DreamCapsuleService {
+  private dreamCapsuleRepository: Repository<DreamCapsule>
+  private interactionLogRepository: Repository<DreamCapsuleInteractionLog>
+
+  constructor(
+    @InjectRepository(DreamCapsule)
+    dreamCapsuleRepository: Repository<DreamCapsule>,
+    @InjectRepository(DreamCapsuleInteractionLog)
+    interactionLogRepository: Repository<DreamCapsuleInteractionLog>,
+    private dreamLogService: DreamLogService,
+    private dreamValidationService: DreamValidationService,
+  ) {
+    this.dreamCapsuleRepository = dreamCapsuleRepository
+    this.interactionLogRepository = interactionLogRepository
+  }
+
+  async createCapsule(createCapsuleDto: CreateDreamCapsuleDto): Promise<DreamCapsuleResponseDto> {
+    const capsule = this.dreamCapsuleRepository.create({
+      ...createCapsuleDto,
+      minimumWordCount: createCapsuleDto.minimumWordCount || 50,
+      cutoffTime: createCapsuleDto.cutoffTime || "09:00:00",
+      timezone: createCapsuleDto.timezone || "UTC",
+      expiresAt: createCapsuleDto.expiresAt ? new Date(createCapsuleDto.expiresAt) : null,
+    })
+
+    const savedCapsule = await this.dreamCapsuleRepository.save(capsule)
+
+    // Log the creation
+    await this.logInteraction(savedCapsule.userId, savedCapsule.id, DreamInteractionType.CREATED, {
+      capsuleType: savedCapsule.type,
+      minimumWordCount: savedCapsule.minimumWordCount,
+      cutoffTime: savedCapsule.cutoffTime,
+    })
+
+    return this.mapToResponseDto(savedCapsule)
+  }
+
+  async getCapsuleById(id: string, userId: string): Promise<DreamCapsuleResponseDto> {
+    const capsule = await this.dreamCapsuleRepository.findOne({
+      where: { id, userId },
+    })
+
+    if (!capsule) {
+      throw new NotFoundException("Dream capsule not found")
+    }
+
+    // Log the view
+    await this.logInteraction(userId, id, DreamInteractionType.VIEWED)
+
+    return this.mapToResponseDto(capsule)
+  }
+
+  async getUserCapsules(userId: string): Promise<DreamCapsuleResponseDto[]> {
+    const capsules = await this.dreamCapsuleRepository.find({
+      where: { userId },
+      order: { createdAt: "DESC" },
+    })
+
+    const results: DreamCapsuleResponseDto[] = []
+
+    for (const capsule of capsules) {
+      results.push(await this.mapToResponseDto(capsule))
+    }
+
+    return results
+  }
+
+  async logDream(userId: string, logDreamDto: LogDreamDto): Promise<LogDreamResponseDto> {
+    try {
+      // Log the dream
+      const dreamLog = await this.dreamLogService.logDream(userId, logDreamDto)
+
+      // Get all user's locked dream capsules
+      const capsules = await this.dreamCapsuleRepository.find({
+        where: { userId, status: DreamCapsuleStatus.LOCKED },
+      })
+
+      let capsuleUnlocked = false
+      let unlockedCapsule: DreamCapsule | null = null
+
+      // Check each capsule to see if it can be unlocked
+      for (const capsule of capsules) {
+        // Validate the dream log against capsule requirements
+        const validation = this.dreamValidationService.validateDreamLog(
+          dreamLog,
+          capsule.minimumWordCount,
+          capsule.cutoffTime,
+        )
+
+        // Log the validation result
+        await this.logInteraction(
+          userId,
+          capsule.id,
+          validation.isValid ? DreamInteractionType.DREAM_VALIDATED : DreamInteractionType.DREAM_REJECTED,
+          {
+            dreamLogId: dreamLog.id,
+            wordCount: dreamLog.wordCount,
+            isBeforeCutoff: dreamLog.isBeforeCutoff,
+            validationReasons: validation.reasons,
+          },
+        )
+
+        // If valid, unlock the capsule
+        if (validation.isValid) {
+          capsule.status = DreamCapsuleStatus.UNLOCKED
+          capsule.unlockedAt = new Date()
+          capsule.unlockedByDreamLogId = dreamLog.id
+          await this.dreamCapsuleRepository.save(capsule)
+
+          // Log the unlock
+          await this.logInteraction(userId, capsule.id, DreamInteractionType.UNLOCKED, {
+            dreamLogId: dreamLog.id,
+          })
+
+          capsuleUnlocked = true
+          unlockedCapsule = capsule
+        }
+      }
+
+      // Prepare response
+      const response: LogDreamResponseDto = {
+        success: true,
+        message: capsuleUnlocked ? "Dream logged successfully and capsule unlocked!" : "Dream logged successfully!",
+        dreamLog: this.mapDreamLogToResponseDto(dreamLog),
+        capsuleUnlocked,
+      }
+
+      if (unlockedCapsule) {
+        response.unlockedCapsule = await this.mapToResponseDto(unlockedCapsule)
+      }
+
+      return response
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error
+      }
+      throw new BadRequestException("Failed to log dream")
+    }
+  }
+
+  private async logInteraction(
+    userId: string,
+    capsuleId: string,
+    type: DreamInteractionType,
+    metadata?: Record<string, any>,
+  ): Promise<void> {
+    const log = this.interactionLogRepository.create({
+      userId,
+      capsuleId,
+      type,
+      dreamLogId: metadata?.dreamLogId,
+      metadata,
+    })
+
+    await this.interactionLogRepository.save(log)
+  }
+
+  private async mapToResponseDto(capsule: DreamCapsule): Promise<DreamCapsuleResponseDto> {
+    // Check if user can unlock today (hasn't logged a dream yet today)
+    const todaysDreamLog = await this.dreamLogService.getTodaysDreamLog(capsule.userId, capsule.timezone)
+    const canUnlockToday = !todaysDreamLog && capsule.status === DreamCapsuleStatus.LOCKED
+
+    const response: DreamCapsuleResponseDto = {
+      id: capsule.id,
+      title: capsule.title,
+      description: capsule.description,
+      content: capsule.status === DreamCapsuleStatus.UNLOCKED ? capsule.content : undefined,
+      type: capsule.type,
+      status: capsule.status,
+      userId: capsule.userId,
+      minimumWordCount: capsule.minimumWordCount,
+      cutoffTime: capsule.cutoffTime,
+      timezone: capsule.timezone,
+      unlockedAt: capsule.unlockedAt,
+      expiresAt: capsule.expiresAt,
+      unlockedByDreamLogId: capsule.unlockedByDreamLogId,
+      metadata: capsule.metadata,
+      createdAt: capsule.createdAt,
+      updatedAt: capsule.updatedAt,
+      canUnlockToday,
+    }
+
+    // Include today's dream log if it exists
+    if (todaysDreamLog) {
+      response.todaysDreamLog = this.mapDreamLogToResponseDto(todaysDreamLog)
+    }
+
+    return response
+  }
+
+  private mapDreamLogToResponseDto(dreamLog: any): DreamLogResponseDto {
+    return {
+      id: dreamLog.id,
+      content: dreamLog.content,
+      wordCount: dreamLog.wordCount,
+      title: dreamLog.title,
+      clarity: dreamLog.clarity,
+      emotion: dreamLog.emotion,
+      isLucid: dreamLog.isLucid,
+      timezone: dreamLog.timezone,
+      isBeforeCutoff: dreamLog.isBeforeCutoff,
+      createdAt: dreamLog.createdAt,
+      logDate: dreamLog.logDate,
+    }
+  }
+}

--- a/apps/capsulelabs-api/src/dream-capsule/services/dream-log.service.ts
+++ b/apps/capsulelabs-api/src/dream-capsule/services/dream-log.service.ts
@@ -1,0 +1,111 @@
+import { Injectable, BadRequestException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { DreamLog } from "../entities/dream-log.entity"
+import type { LogDreamDto } from "../dto/log-dream.dto"
+import type { DreamValidationService } from "./dream-validation.service"
+
+@Injectable()
+export class DreamLogService {
+  constructor(
+    @InjectRepository(DreamLog)
+    private dreamLogRepository: Repository<DreamLog>,
+    private dreamValidationService: DreamValidationService,
+  ) {}
+
+  async logDream(userId: string, logDreamDto: LogDreamDto): Promise<DreamLog> {
+    const { content, title, clarity, emotion, isLucid, timezone = "UTC", metadata } = logDreamDto
+
+    // Count words in the dream content
+    const wordCount = this.dreamValidationService.countWords(content)
+
+    if (wordCount === 0) {
+      throw new BadRequestException("Dream content cannot be empty")
+    }
+
+    // Check if the dream is logged before the cutoff time (9 AM by default)
+    const isBeforeCutoff = this.dreamValidationService.isBeforeCutoff("09:00:00", timezone)
+
+    // Get today's date in the user's timezone
+    const today = this.getTodayInTimezone(timezone)
+
+    // Check if user already logged a dream today
+    const existingLog = await this.dreamLogRepository.findOne({
+      where: {
+        userId,
+        logDate: today,
+      },
+    })
+
+    if (existingLog) {
+      throw new BadRequestException("You have already logged a dream today")
+    }
+
+    // Create new dream log
+    const dreamLog = this.dreamLogRepository.create({
+      userId,
+      content,
+      wordCount,
+      title,
+      clarity,
+      emotion,
+      isLucid,
+      timezone,
+      isBeforeCutoff,
+      metadata,
+      logDate: today,
+    })
+
+    return await this.dreamLogRepository.save(dreamLog)
+  }
+
+  async getDreamLogById(id: string, userId: string): Promise<DreamLog> {
+    const dreamLog = await this.dreamLogRepository.findOne({
+      where: { id, userId },
+    })
+
+    if (!dreamLog) {
+      throw new BadRequestException("Dream log not found")
+    }
+
+    return dreamLog
+  }
+
+  async getUserDreamLogs(userId: string, limit = 30): Promise<DreamLog[]> {
+    return await this.dreamLogRepository.find({
+      where: { userId },
+      order: { logDate: "DESC" },
+      take: limit,
+    })
+  }
+
+  async getTodaysDreamLog(userId: string, timezone = "UTC"): Promise<DreamLog | null> {
+    const today = this.getTodayInTimezone(timezone)
+
+    return await this.dreamLogRepository.findOne({
+      where: {
+        userId,
+        logDate: today,
+      },
+    })
+  }
+
+  async getDreamLogsByDateRange(userId: string, startDate: Date, endDate: Date): Promise<DreamLog[]> {
+    return await this.dreamLogRepository.find({
+      where: {
+        userId,
+        logDate: Between(startDate, endDate),
+      },
+      order: { logDate: "ASC" },
+    })
+  }
+
+  private getTodayInTimezone(timezone: string): Date {
+    const now = new Date()
+
+    // Get just the date part (year, month, day)
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  }
+}
+
+import { Between } from "typeorm"

--- a/apps/capsulelabs-api/src/dream-capsule/services/dream-validation.service.ts
+++ b/apps/capsulelabs-api/src/dream-capsule/services/dream-validation.service.ts
@@ -1,0 +1,68 @@
+import { Injectable } from "@nestjs/common"
+import type { DreamLog } from "../entities/dream-log.entity"
+
+@Injectable()
+export class DreamValidationService {
+  /**
+   * Count words in a text string
+   */
+  countWords(text: string): number {
+    if (!text || typeof text !== "string") return 0
+
+    // Remove extra whitespace and split by spaces
+    return text
+      .trim()
+      .replace(/\s+/g, " ")
+      .split(" ")
+      .filter((word) => word.length > 0).length
+  }
+
+  /**
+   * Check if the current time is before the cutoff time in the specified timezone
+   */
+  isBeforeCutoff(cutoffTime: string, timezone = "UTC"): boolean {
+    try {
+      // Get current time in the specified timezone
+      const now = new Date()
+
+      // Parse cutoff time (format: "HH:MM:SS")
+      const [hours, minutes, seconds] = cutoffTime.split(":").map(Number)
+
+      // Create cutoff time for today
+      const cutoff = new Date(now)
+      cutoff.setHours(hours, minutes, seconds || 0, 0)
+
+      // Compare current time with cutoff time
+      return now < cutoff
+    } catch (error) {
+      console.error("Error checking cutoff time:", error)
+      return false
+    }
+  }
+
+  /**
+   * Validate a dream log against requirements
+   */
+  validateDreamLog(
+    dreamLog: DreamLog,
+    minimumWordCount: number,
+    cutoffTime: string,
+  ): { isValid: boolean; reasons: string[] } {
+    const reasons: string[] = []
+
+    // Check word count
+    if (dreamLog.wordCount < minimumWordCount) {
+      reasons.push(`Dream log must be at least ${minimumWordCount} words (currently ${dreamLog.wordCount})`)
+    }
+
+    // Check if created before cutoff time
+    if (!dreamLog.isBeforeCutoff) {
+      reasons.push(`Dream must be logged before ${cutoffTime} (${dreamLog.timezone})`)
+    }
+
+    return {
+      isValid: reasons.length === 0,
+      reasons,
+    }
+  }
+}

--- a/apps/capsulelabs-api/src/memory-capsule/controllers/memory-capsule.controller.ts
+++ b/apps/capsulelabs-api/src/memory-capsule/controllers/memory-capsule.controller.ts
@@ -1,0 +1,63 @@
+import { Controller, Get, Post, Body, Param, Query, ParseUUIDPipe, ValidationPipe } from "@nestjs/common"
+import type { MemoryCapsuleService } from "../services/memory-capsule.service"
+import type { CreateMemoryCapsuleDto } from "../dto/create-memory-capsule.dto"
+import type { AnswerMemoryQuestionDto } from "../dto/answer-memory-question.dto"
+import type { CreateDailyLogDto } from "../dto/create-daily-log.dto"
+import type { MemoryCapsuleResponseDto, UnlockAttemptResponseDto } from "../dto/memory-capsule-response.dto"
+import type { DailyLog } from "../entities/daily-log.entity"
+
+// Note: You'll need to implement your own authentication guard
+// import { AuthGuard } from '@nestjs/passport';
+// import { GetUser } from '../auth/get-user.decorator';
+
+@Controller("memory-capsules")
+// @UseGuards(AuthGuard())
+export class MemoryCapsuleController {
+  constructor(private readonly memoryCapsuleService: MemoryCapsuleService) {}
+
+  @Post()
+  async createCapsule(
+    @Body() createCapsuleDto: CreateMemoryCapsuleDto,
+  ): Promise<MemoryCapsuleResponseDto> {
+    return await this.memoryCapsuleService.createCapsule(createCapsuleDto);
+  }
+
+  @Get()
+  async getUserCapsules(
+    @Query('userId') userId: string,
+  ): Promise<MemoryCapsuleResponseDto[]> {
+    return await this.memoryCapsuleService.getUserCapsules(userId);
+  }
+
+  @Get(":id")
+  async getCapsuleById(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('userId') userId: string,
+  ): Promise<MemoryCapsuleResponseDto> {
+    return await this.memoryCapsuleService.getCapsuleById(id, userId)
+  }
+
+  @Post(":id/unlock")
+  async attemptUnlock(
+    @Param('id', ParseUUIDPipe) capsuleId: string,
+    @Body(ValidationPipe) answerDto: AnswerMemoryQuestionDto,
+    @Query('userId') userId: string,
+  ): Promise<UnlockAttemptResponseDto> {
+    return await this.memoryCapsuleService.attemptUnlock(capsuleId, answerDto, userId)
+  }
+
+  @Post('daily-logs')
+  async createDailyLog(
+    @Body(ValidationPipe) createDailyLogDto: CreateDailyLogDto,
+  ): Promise<DailyLog> {
+    return await this.memoryCapsuleService.createDailyLog(createDailyLogDto);
+  }
+
+  @Get("daily-logs/:userId")
+  async getUserDailyLogs(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Query('limit') limit?: number,
+  ): Promise<DailyLog[]> {
+    return await this.memoryCapsuleService.getUserDailyLogs(userId, limit)
+  }
+}

--- a/apps/capsulelabs-api/src/memory-capsule/dto/answer-memory-question.dto.ts
+++ b/apps/capsulelabs-api/src/memory-capsule/dto/answer-memory-question.dto.ts
@@ -1,0 +1,13 @@
+import { IsString, IsObject, IsOptional } from "class-validator"
+
+export class AnswerMemoryQuestionDto {
+  @IsString()
+  questionId: string
+
+  @IsObject()
+  answer: Record<string, any>
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/memory-capsule/dto/create-daily-log.dto.ts
+++ b/apps/capsulelabs-api/src/memory-capsule/dto/create-daily-log.dto.ts
@@ -1,0 +1,25 @@
+import { IsString, IsOptional, IsEnum, IsDateString, IsArray } from "class-validator"
+import { MoodType } from "../entities/daily-log.entity"
+
+export class CreateDailyLogDto {
+  @IsString()
+  userId: string
+
+  @IsDateString()
+  logDate: string
+
+  @IsOptional()
+  @IsEnum(MoodType)
+  mood?: MoodType
+
+  @IsOptional()
+  @IsString()
+  notes?: string
+
+  @IsOptional()
+  @IsArray()
+  activities?: string[]
+
+  @IsOptional()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/memory-capsule/dto/create-memory-capsule.dto.ts
+++ b/apps/capsulelabs-api/src/memory-capsule/dto/create-memory-capsule.dto.ts
@@ -1,0 +1,34 @@
+import { IsString, IsOptional, IsEnum, IsDateString, IsObject, IsInt, Min, Max } from "class-validator"
+import { CapsuleType } from "../entities/memory-capsule.entity"
+
+export class CreateMemoryCapsuleDto {
+  @IsString()
+  title: string
+
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @IsObject()
+  content: Record<string, any>
+
+  @IsEnum(CapsuleType)
+  type: CapsuleType
+
+  @IsString()
+  userId: string
+
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  maxUnlockAttempts?: number
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/memory-capsule/dto/memory-capsule-response.dto.ts
+++ b/apps/capsulelabs-api/src/memory-capsule/dto/memory-capsule-response.dto.ts
@@ -1,0 +1,37 @@
+import type { CapsuleStatus, CapsuleType } from "../entities/memory-capsule.entity"
+import type { QuestionStatus, QuestionType } from "../entities/memory-question.entity"
+
+export class MemoryCapsuleResponseDto {
+  id: string
+  title: string
+  description?: string
+  content?: Record<string, any>
+  type: CapsuleType
+  status: CapsuleStatus
+  userId: string
+  unlockedAt?: Date
+  expiresAt?: Date
+  unlockAttempts: number
+  maxUnlockAttempts: number
+  metadata?: Record<string, any>
+  createdAt: Date
+  updatedAt: Date
+  currentQuestion?: MemoryQuestionResponseDto
+}
+
+export class MemoryQuestionResponseDto {
+  id: string
+  question: string
+  type: QuestionType
+  status: QuestionStatus
+  answeredAt?: Date
+  expiresAt?: Date
+  createdAt: Date
+}
+
+export class UnlockAttemptResponseDto {
+  success: boolean
+  message: string
+  capsule?: MemoryCapsuleResponseDto
+  remainingAttempts?: number
+}

--- a/apps/capsulelabs-api/src/memory-capsule/entities/capsule-interaction-log.entity.ts
+++ b/apps/capsulelabs-api/src/memory-capsule/entities/capsule-interaction-log.entity.ts
@@ -1,0 +1,51 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, JoinColumn } from "typeorm"
+import { MemoryCapsule } from "./memory-capsule.entity"
+
+export enum InteractionType {
+  CREATED = "created",
+  VIEWED = "viewed",
+  UNLOCK_ATTEMPTED = "unlock_attempted",
+  UNLOCKED = "unlocked",
+  QUESTION_ANSWERED = "question_answered",
+  EXPIRED = "expired",
+}
+
+@Entity("capsule_interaction_logs")
+export class CapsuleInteractionLog {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "uuid" })
+  capsuleId: string
+
+  @Column({
+    type: "enum",
+    enum: InteractionType,
+  })
+  type: InteractionType
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  userAgent: string
+
+  @Column({ type: "inet", nullable: true })
+  ipAddress: string
+
+  @CreateDateColumn()
+  timestamp: Date
+
+  @ManyToOne(
+    () => MemoryCapsule,
+    (capsule) => capsule.interactionLogs,
+    {
+      onDelete: "CASCADE",
+    },
+  )
+  @JoinColumn({ name: "capsuleId" })
+  capsule: MemoryCapsule
+}

--- a/apps/capsulelabs-api/src/memory-capsule/entities/daily-log.entity.ts
+++ b/apps/capsulelabs-api/src/memory-capsule/entities/daily-log.entity.ts
@@ -1,0 +1,46 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from "typeorm"
+
+export enum MoodType {
+  VERY_HAPPY = "very_happy",
+  HAPPY = "happy",
+  NEUTRAL = "neutral",
+  SAD = "sad",
+  VERY_SAD = "very_sad",
+  ANXIOUS = "anxious",
+  EXCITED = "excited",
+  CALM = "calm",
+}
+
+@Entity("daily_logs")
+export class DailyLog {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "date" })
+  logDate: Date
+
+  @Column({
+    type: "enum",
+    enum: MoodType,
+    nullable: true,
+  })
+  mood: MoodType
+
+  @Column({ type: "text", nullable: true })
+  notes: string
+
+  @Column({ type: "jsonb", nullable: true })
+  activities: string[]
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+}

--- a/apps/capsulelabs-api/src/memory-capsule/entities/memory-capsule.entity.ts
+++ b/apps/capsulelabs-api/src/memory-capsule/entities/memory-capsule.entity.ts
@@ -1,0 +1,82 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from "typeorm"
+import { CapsuleInteractionLog } from "./capsule-interaction-log.entity"
+import { MemoryQuestion } from "./memory-question.entity"
+
+export enum CapsuleStatus {
+  LOCKED = "locked",
+  UNLOCKED = "unlocked",
+  EXPIRED = "expired",
+}
+
+export enum CapsuleType {
+  TEXT = "text",
+  IMAGE = "image",
+  VIDEO = "video",
+  AUDIO = "audio",
+  MIXED = "mixed",
+}
+
+@Entity("memory_capsules")
+export class MemoryCapsule {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "varchar", length: 255 })
+  title: string
+
+  @Column({ type: "text", nullable: true })
+  description: string
+
+  @Column({ type: "jsonb" })
+  content: Record<string, any>
+
+  @Column({
+    type: "enum",
+    enum: CapsuleType,
+    default: CapsuleType.TEXT,
+  })
+  type: CapsuleType
+
+  @Column({
+    type: "enum",
+    enum: CapsuleStatus,
+    default: CapsuleStatus.LOCKED,
+  })
+  status: CapsuleStatus
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "timestamp", nullable: true })
+  unlockedAt: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  expiresAt: Date
+
+  @Column({ type: "int", default: 0 })
+  unlockAttempts: number
+
+  @Column({ type: "int", default: 3 })
+  maxUnlockAttempts: number
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+
+  @OneToMany(
+    () => CapsuleInteractionLog,
+    (log) => log.capsule,
+  )
+  interactionLogs: CapsuleInteractionLog[]
+
+  @OneToMany(
+    () => MemoryQuestion,
+    (question) => question.capsule,
+  )
+  memoryQuestions: MemoryQuestion[]
+}

--- a/apps/capsulelabs-api/src/memory-capsule/entities/memory-question.entity.ts
+++ b/apps/capsulelabs-api/src/memory-capsule/entities/memory-question.entity.ts
@@ -1,0 +1,84 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from "typeorm"
+import { MemoryCapsule } from "./memory-capsule.entity"
+
+export enum QuestionType {
+  MOOD = "mood",
+  CAPSULE_INTERACTION = "capsule_interaction",
+  DAILY_ACTIVITY = "daily_activity",
+  TIMESTAMP = "timestamp",
+  CONTENT_BASED = "content_based",
+}
+
+export enum QuestionStatus {
+  ACTIVE = "active",
+  ANSWERED_CORRECT = "answered_correct",
+  ANSWERED_INCORRECT = "answered_incorrect",
+  EXPIRED = "expired",
+}
+
+@Entity("memory_questions")
+export class MemoryQuestion {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  capsuleId: string
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "text" })
+  question: string
+
+  @Column({ type: "jsonb" })
+  correctAnswer: Record<string, any>
+
+  @Column({ type: "jsonb", nullable: true })
+  userAnswer: Record<string, any>
+
+  @Column({
+    type: "enum",
+    enum: QuestionType,
+  })
+  type: QuestionType
+
+  @Column({
+    type: "enum",
+    enum: QuestionStatus,
+    default: QuestionStatus.ACTIVE,
+  })
+  status: QuestionStatus
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @Column({ type: "timestamp", nullable: true })
+  answeredAt: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  expiresAt: Date
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+
+  @ManyToOne(
+    () => MemoryCapsule,
+    (capsule) => capsule.memoryQuestions,
+    {
+      onDelete: "CASCADE",
+    },
+  )
+  @JoinColumn({ name: "capsuleId" })
+  capsule: MemoryCapsule
+}

--- a/apps/capsulelabs-api/src/memory-capsule/memory-capsule.module.ts
+++ b/apps/capsulelabs-api/src/memory-capsule/memory-capsule.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { MemoryCapsuleController } from "./controllers/memory-capsule.controller"
+import { MemoryCapsuleService } from "./services/memory-capsule.service"
+import { QuestionGeneratorService } from "./services/question-generator.service"
+import { AnswerValidationService } from "./services/answer-validation.service"
+import { MemoryCapsule } from "./entities/memory-capsule.entity"
+import { CapsuleInteractionLog } from "./entities/capsule-interaction-log.entity"
+import { MemoryQuestion } from "./entities/memory-question.entity"
+import { DailyLog } from "./entities/daily-log.entity"
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MemoryCapsule, CapsuleInteractionLog, MemoryQuestion, DailyLog])],
+  controllers: [MemoryCapsuleController],
+  providers: [MemoryCapsuleService, QuestionGeneratorService, AnswerValidationService],
+  exports: [MemoryCapsuleService],
+})
+export class MemoryCapsuleModule {}

--- a/apps/capsulelabs-api/src/memory-capsule/services/answer-validation.service.ts
+++ b/apps/capsulelabs-api/src/memory-capsule/services/answer-validation.service.ts
@@ -1,0 +1,111 @@
+import { Injectable } from "@nestjs/common"
+import { type MemoryQuestion, QuestionType } from "../entities/memory-question.entity"
+
+@Injectable()
+export class AnswerValidationService {
+  validateAnswer(question: MemoryQuestion, userAnswer: Record<string, any>): boolean {
+    switch (question.type) {
+      case QuestionType.MOOD:
+        return this.validateMoodAnswer(question, userAnswer)
+      case QuestionType.CAPSULE_INTERACTION:
+        return this.validateCapsuleInteractionAnswer(question, userAnswer)
+      case QuestionType.DAILY_ACTIVITY:
+        return this.validateDailyActivityAnswer(question, userAnswer)
+      case QuestionType.TIMESTAMP:
+        return this.validateTimestampAnswer(question, userAnswer)
+      default:
+        return false
+    }
+  }
+
+  private validateMoodAnswer(question: MemoryQuestion, userAnswer: Record<string, any>): boolean {
+    const correctMood = question.correctAnswer.mood
+    const userMood = userAnswer.mood
+
+    return correctMood === userMood
+  }
+
+  private validateCapsuleInteractionAnswer(question: MemoryQuestion, userAnswer: Record<string, any>): boolean {
+    const correctTitle = question.correctAnswer.capsuleTitle?.toLowerCase().trim()
+    const userTitle = userAnswer.capsuleTitle?.toLowerCase().trim()
+
+    if (correctTitle && userTitle) {
+      // Allow partial matches for capsule titles
+      return correctTitle.includes(userTitle) || userTitle.includes(correctTitle)
+    }
+
+    // Also check by ID if provided
+    if (question.correctAnswer.capsuleId && userAnswer.capsuleId) {
+      return question.correctAnswer.capsuleId === userAnswer.capsuleId
+    }
+
+    return false
+  }
+
+  private validateDailyActivityAnswer(question: MemoryQuestion, userAnswer: Record<string, any>): boolean {
+    const correctActivities = question.correctAnswer.activities || []
+    const userActivities = userAnswer.activities || []
+
+    if (correctActivities.length === 0) return false
+
+    // Check if at least 50% of activities match
+    const matchingActivities = userActivities.filter((activity) =>
+      correctActivities.some(
+        (correct) =>
+          correct.toLowerCase().includes(activity.toLowerCase()) ||
+          activity.toLowerCase().includes(correct.toLowerCase()),
+      ),
+    )
+
+    return matchingActivities.length >= Math.ceil(correctActivities.length * 0.5)
+  }
+
+  private validateTimestampAnswer(question: MemoryQuestion, userAnswer: Record<string, any>): boolean {
+    const correctDayOfWeek = question.correctAnswer.dayOfWeek?.toLowerCase()
+    const userDayOfWeek = userAnswer.dayOfWeek?.toLowerCase()
+
+    return correctDayOfWeek === userDayOfWeek
+  }
+
+  calculateSimilarity(correct: string, user: string): number {
+    if (!correct || !user) return 0
+
+    const correctLower = correct.toLowerCase().trim()
+    const userLower = user.toLowerCase().trim()
+
+    if (correctLower === userLower) return 1
+
+    // Simple similarity calculation
+    const longer = correctLower.length > userLower.length ? correctLower : userLower
+    const shorter = correctLower.length > userLower.length ? userLower : correctLower
+
+    if (longer.length === 0) return 1
+
+    const editDistance = this.levenshteinDistance(longer, shorter)
+    return (longer.length - editDistance) / longer.length
+  }
+
+  private levenshteinDistance(str1: string, str2: string): number {
+    const matrix = []
+
+    for (let i = 0; i <= str2.length; i++) {
+      matrix[i] = [i]
+    }
+
+    for (let j = 0; j <= str1.length; j++) {
+      matrix[0][j] = j
+    }
+
+    for (let i = 1; i <= str2.length; i++) {
+      for (let j = 1; j <= str1.length; j++) {
+        if (str2.charAt(i - 1) === str1.charAt(j - 1)) {
+          matrix[i][j] = matrix[i - 1][j - 1]
+        } else {
+          matrix[i][j] = Math.min(matrix[i - 1][j - 1] + 1, matrix[i][j - 1] + 1, matrix[i - 1][j] + 1)
+        }
+      }
+    }
+
+    return matrix[str2.length][str1.length]
+  }
+}

--- a/apps/capsulelabs-api/src/memory-capsule/services/memory-capsule.service.ts
+++ b/apps/capsulelabs-api/src/memory-capsule/services/memory-capsule.service.ts
@@ -1,0 +1,273 @@
+import { Injectable, NotFoundException, BadRequestException, ForbiddenException } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import { type MemoryCapsule, CapsuleStatus } from "../entities/memory-capsule.entity"
+import { type CapsuleInteractionLog, InteractionType } from "../entities/capsule-interaction-log.entity"
+import { type MemoryQuestion, QuestionStatus } from "../entities/memory-question.entity"
+import type { DailyLog } from "../entities/daily-log.entity"
+import type { CreateMemoryCapsuleDto } from "../dto/create-memory-capsule.dto"
+import type { AnswerMemoryQuestionDto } from "../dto/answer-memory-question.dto"
+import type { CreateDailyLogDto } from "../dto/create-daily-log.dto"
+import type { MemoryCapsuleResponseDto, UnlockAttemptResponseDto } from "../dto/memory-capsule-response.dto"
+import type { QuestionGeneratorService } from "./question-generator.service"
+import type { AnswerValidationService } from "./answer-validation.service"
+
+@Injectable()
+export class MemoryCapsuleService {
+  constructor(
+    private memoryCapsuleRepository: Repository<MemoryCapsule>,
+    private interactionLogRepository: Repository<CapsuleInteractionLog>,
+    private memoryQuestionRepository: Repository<MemoryQuestion>,
+    private dailyLogRepository: Repository<DailyLog>,
+    private questionGeneratorService: QuestionGeneratorService,
+    private answerValidationService: AnswerValidationService,
+  ) {}
+
+  async createCapsule(createCapsuleDto: CreateMemoryCapsuleDto): Promise<MemoryCapsuleResponseDto> {
+    const capsule = this.memoryCapsuleRepository.create({
+      ...createCapsuleDto,
+      expiresAt: createCapsuleDto.expiresAt ? new Date(createCapsuleDto.expiresAt) : null,
+    })
+
+    const savedCapsule = await this.memoryCapsuleRepository.save(capsule)
+
+    // Log the creation
+    await this.logInteraction(savedCapsule.userId, savedCapsule.id, InteractionType.CREATED, {
+      capsuleType: savedCapsule.type,
+    })
+
+    return this.mapToResponseDto(savedCapsule)
+  }
+
+  async getCapsuleById(id: string, userId: string): Promise<MemoryCapsuleResponseDto> {
+    const capsule = await this.memoryCapsuleRepository.findOne({
+      where: { id, userId },
+      relations: ["memoryQuestions"],
+    })
+
+    if (!capsule) {
+      throw new NotFoundException("Capsule not found")
+    }
+
+    // Log the view
+    await this.logInteraction(userId, id, InteractionType.VIEWED)
+
+    const response = this.mapToResponseDto(capsule)
+
+    // Add current active question if capsule is locked
+    if (capsule.status === CapsuleStatus.LOCKED) {
+      const activeQuestion = await this.getOrCreateActiveQuestion(capsule)
+      if (activeQuestion) {
+        response.currentQuestion = {
+          id: activeQuestion.id,
+          question: activeQuestion.question,
+          type: activeQuestion.type,
+          status: activeQuestion.status,
+          answeredAt: activeQuestion.answeredAt,
+          expiresAt: activeQuestion.expiresAt,
+          createdAt: activeQuestion.createdAt,
+        }
+      }
+    }
+
+    return response
+  }
+
+  async getUserCapsules(userId: string): Promise<MemoryCapsuleResponseDto[]> {
+    const capsules = await this.memoryCapsuleRepository.find({
+      where: { userId },
+      order: { createdAt: "DESC" },
+    })
+
+    return capsules.map((capsule) => this.mapToResponseDto(capsule))
+  }
+
+  async attemptUnlock(
+    capsuleId: string,
+    answerDto: AnswerMemoryQuestionDto,
+    userId: string,
+  ): Promise<UnlockAttemptResponseDto> {
+    const capsule = await this.memoryCapsuleRepository.findOne({
+      where: { id: capsuleId, userId },
+    })
+
+    if (!capsule) {
+      throw new NotFoundException("Capsule not found")
+    }
+
+    if (capsule.status !== CapsuleStatus.LOCKED) {
+      throw new BadRequestException("Capsule is not locked")
+    }
+
+    if (capsule.unlockAttempts >= capsule.maxUnlockAttempts) {
+      throw new ForbiddenException("Maximum unlock attempts exceeded")
+    }
+
+    const question = await this.memoryQuestionRepository.findOne({
+      where: { id: answerDto.questionId, capsuleId, userId },
+    })
+
+    if (!question) {
+      throw new NotFoundException("Question not found")
+    }
+
+    if (question.status !== QuestionStatus.ACTIVE) {
+      throw new BadRequestException("Question is not active")
+    }
+
+    // Validate the answer
+    const isCorrect = this.answerValidationService.validateAnswer(question, answerDto.answer)
+
+    // Update question with user's answer
+    question.userAnswer = answerDto.answer
+    question.answeredAt = new Date()
+    question.status = isCorrect ? QuestionStatus.ANSWERED_CORRECT : QuestionStatus.ANSWERED_INCORRECT
+    await this.memoryQuestionRepository.save(question)
+
+    // Update capsule unlock attempts
+    capsule.unlockAttempts += 1
+
+    // Log the attempt
+    await this.logInteraction(userId, capsuleId, InteractionType.QUESTION_ANSWERED, {
+      questionId: question.id,
+      isCorrect,
+      attempt: capsule.unlockAttempts,
+    })
+
+    if (isCorrect) {
+      // Unlock the capsule
+      capsule.status = CapsuleStatus.UNLOCKED
+      capsule.unlockedAt = new Date()
+      await this.memoryCapsuleRepository.save(capsule)
+
+      // Log successful unlock
+      await this.logInteraction(userId, capsuleId, InteractionType.UNLOCKED)
+
+      return {
+        success: true,
+        message: "Capsule unlocked successfully!",
+        capsule: this.mapToResponseDto(capsule),
+      }
+    } else {
+      await this.memoryCapsuleRepository.save(capsule)
+
+      const remainingAttempts = capsule.maxUnlockAttempts - capsule.unlockAttempts
+
+      if (remainingAttempts <= 0) {
+        // Mark capsule as expired if no attempts left
+        capsule.status = CapsuleStatus.EXPIRED
+        await this.memoryCapsuleRepository.save(capsule)
+
+        await this.logInteraction(userId, capsuleId, InteractionType.EXPIRED)
+
+        return {
+          success: false,
+          message: "Incorrect answer. Capsule has been locked permanently.",
+          remainingAttempts: 0,
+        }
+      }
+
+      return {
+        success: false,
+        message: `Incorrect answer. ${remainingAttempts} attempts remaining.`,
+        remainingAttempts,
+      }
+    }
+  }
+
+  async createDailyLog(createDailyLogDto: CreateDailyLogDto): Promise<DailyLog> {
+    // Check if log already exists for this date
+    const existingLog = await this.dailyLogRepository.findOne({
+      where: {
+        userId: createDailyLogDto.userId,
+        logDate: new Date(createDailyLogDto.logDate),
+      },
+    })
+
+    if (existingLog) {
+      // Update existing log
+      Object.assign(existingLog, {
+        ...createDailyLogDto,
+        logDate: new Date(createDailyLogDto.logDate),
+      })
+      return await this.dailyLogRepository.save(existingLog)
+    }
+
+    const dailyLog = this.dailyLogRepository.create({
+      ...createDailyLogDto,
+      logDate: new Date(createDailyLogDto.logDate),
+    })
+
+    return await this.dailyLogRepository.save(dailyLog)
+  }
+
+  async getUserDailyLogs(userId: string, limit = 30): Promise<DailyLog[]> {
+    return await this.dailyLogRepository.find({
+      where: { userId },
+      order: { logDate: "DESC" },
+      take: limit,
+    })
+  }
+
+  private async getOrCreateActiveQuestion(capsule: MemoryCapsule): Promise<MemoryQuestion | null> {
+    // Check for existing active question
+    let activeQuestion = await this.memoryQuestionRepository.findOne({
+      where: {
+        capsuleId: capsule.id,
+        status: QuestionStatus.ACTIVE,
+      },
+    })
+
+    if (!activeQuestion) {
+      // Generate new question
+      const questionData = await this.questionGeneratorService.generateQuestionForCapsule(capsule)
+
+      if (questionData) {
+        activeQuestion = this.memoryQuestionRepository.create({
+          ...questionData,
+          capsuleId: capsule.id,
+          userId: capsule.userId,
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours from now
+        })
+
+        activeQuestion = await this.memoryQuestionRepository.save(activeQuestion)
+      }
+    }
+
+    return activeQuestion
+  }
+
+  private async logInteraction(
+    userId: string,
+    capsuleId: string,
+    type: InteractionType,
+    metadata?: Record<string, any>,
+  ): Promise<void> {
+    const log = this.interactionLogRepository.create({
+      userId,
+      capsuleId,
+      type,
+      metadata,
+    })
+
+    await this.interactionLogRepository.save(log)
+  }
+
+  private mapToResponseDto(capsule: MemoryCapsule): MemoryCapsuleResponseDto {
+    return {
+      id: capsule.id,
+      title: capsule.title,
+      description: capsule.description,
+      content: capsule.status === CapsuleStatus.UNLOCKED ? capsule.content : undefined,
+      type: capsule.type,
+      status: capsule.status,
+      userId: capsule.userId,
+      unlockedAt: capsule.unlockedAt,
+      expiresAt: capsule.expiresAt,
+      unlockAttempts: capsule.unlockAttempts,
+      maxUnlockAttempts: capsule.maxUnlockAttempts,
+      metadata: capsule.metadata,
+      createdAt: capsule.createdAt,
+      updatedAt: capsule.updatedAt,
+    }
+  }
+}

--- a/apps/capsulelabs-api/src/memory-capsule/services/question-generator.service.ts
+++ b/apps/capsulelabs-api/src/memory-capsule/services/question-generator.service.ts
@@ -1,0 +1,177 @@
+import { Injectable } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { CapsuleInteractionLog, InteractionType } from "../entities/capsule-interaction-log.entity"
+import { DailyLog } from "../entities/daily-log.entity"
+import { MemoryQuestion, QuestionType } from "../entities/memory-question.entity"
+import type { MemoryCapsule } from "../entities/memory-capsule.entity"
+
+@Injectable()
+export class QuestionGeneratorService {
+  private interactionLogRepository: Repository<CapsuleInteractionLog>
+  private dailyLogRepository: Repository<DailyLog>
+  private memoryQuestionRepository: Repository<MemoryQuestion>;
+
+  constructor(
+    @InjectRepository(CapsuleInteractionLog)
+    interactionLogRepository: Repository<CapsuleInteractionLog>,
+    @InjectRepository(DailyLog)
+    dailyLogRepository: Repository<DailyLog>,
+    @InjectRepository(MemoryQuestion)
+    private memoryQuestionRepository: Repository<MemoryQuestion>,
+  ) {}
+
+  async generateQuestionForCapsule(capsule: MemoryCapsule): Promise<Partial<MemoryQuestion>> {
+    const questionTypes = [
+      QuestionType.MOOD,
+      QuestionType.CAPSULE_INTERACTION,
+      QuestionType.DAILY_ACTIVITY,
+      QuestionType.TIMESTAMP,
+    ]
+
+    // Randomly select a question type
+    const selectedType = questionTypes[Math.floor(Math.random() * questionTypes.length)]
+
+    switch (selectedType) {
+      case QuestionType.MOOD:
+        return await this.generateMoodQuestion(capsule.userId)
+      case QuestionType.CAPSULE_INTERACTION:
+        return await this.generateCapsuleInteractionQuestion(capsule.userId)
+      case QuestionType.DAILY_ACTIVITY:
+        return await this.generateDailyActivityQuestion(capsule.userId)
+      case QuestionType.TIMESTAMP:
+        return await this.generateTimestampQuestion(capsule.userId)
+      default:
+        return await this.generateMoodQuestion(capsule.userId)
+    }
+  }
+
+  private async generateMoodQuestion(userId: string): Promise<Partial<MemoryQuestion>> {
+    const daysAgo = Math.floor(Math.random() * 7) + 1 // 1-7 days ago
+    const targetDate = new Date()
+    targetDate.setDate(targetDate.getDate() - daysAgo)
+
+    const dailyLog = await this.dailyLogRepository.findOne({
+      where: {
+        userId,
+        logDate: targetDate,
+      },
+    })
+
+    if (!dailyLog || !dailyLog.mood) {
+      // Fallback to a different question type if no mood data
+      return await this.generateCapsuleInteractionQuestion(userId)
+    }
+
+    const dayText = daysAgo === 1 ? "yesterday" : `${daysAgo} days ago`
+
+    return {
+      question: `What was your mood ${dayText}?`,
+      correctAnswer: { mood: dailyLog.mood },
+      type: QuestionType.MOOD,
+      metadata: {
+        targetDate: targetDate.toISOString(),
+        daysAgo,
+      },
+    }
+  }
+
+  private async generateCapsuleInteractionQuestion(userId: string): Promise<Partial<MemoryQuestion>> {
+    const recentInteractions = await this.interactionLogRepository.find({
+      where: {
+        userId,
+        type: InteractionType.UNLOCKED,
+      },
+      relations: ["capsule"],
+      order: { timestamp: "DESC" },
+      take: 10,
+    })
+
+    if (recentInteractions.length === 0) {
+      return await this.generateTimestampQuestion(userId)
+    }
+
+    const randomInteraction = recentInteractions[Math.floor(Math.random() * recentInteractions.length)]
+    const daysDiff = Math.floor((Date.now() - randomInteraction.timestamp.getTime()) / (1000 * 60 * 60 * 24))
+
+    let timeText = "recently"
+    if (daysDiff === 0) timeText = "today"
+    else if (daysDiff === 1) timeText = "yesterday"
+    else if (daysDiff <= 7) timeText = `${daysDiff} days ago`
+    else timeText = "last week"
+
+    return {
+      question: `Which capsule did you unlock ${timeText}?`,
+      correctAnswer: {
+        capsuleTitle: randomInteraction.capsule.title,
+        capsuleId: randomInteraction.capsule.id,
+      },
+      type: QuestionType.CAPSULE_INTERACTION,
+      metadata: {
+        targetInteractionId: randomInteraction.id,
+        targetDate: randomInteraction.timestamp.toISOString(),
+      },
+    }
+  }
+
+  private async generateDailyActivityQuestion(userId: string): Promise<Partial<MemoryQuestion>> {
+    const daysAgo = Math.floor(Math.random() * 5) + 1 // 1-5 days ago
+    const targetDate = new Date()
+    targetDate.setDate(targetDate.getDate() - daysAgo)
+
+    const dailyLog = await this.dailyLogRepository.findOne({
+      where: {
+        userId,
+        logDate: targetDate,
+      },
+    })
+
+    if (!dailyLog || !dailyLog.activities || dailyLog.activities.length === 0) {
+      return await this.generateMoodQuestion(userId)
+    }
+
+    const dayText = daysAgo === 1 ? "yesterday" : `${daysAgo} days ago`
+
+    return {
+      question: `What activities did you do ${dayText}?`,
+      correctAnswer: { activities: dailyLog.activities },
+      type: QuestionType.DAILY_ACTIVITY,
+      metadata: {
+        targetDate: targetDate.toISOString(),
+        daysAgo,
+      },
+    }
+  }
+
+  private async generateTimestampQuestion(userId: string): Promise<Partial<MemoryQuestion>> {
+    const recentLogs = await this.interactionLogRepository.find({
+      where: { userId },
+      order: { timestamp: "DESC" },
+      take: 20,
+    })
+
+    if (recentLogs.length === 0) {
+      // Fallback question
+      return {
+        question: "What day of the week is it today?",
+        correctAnswer: { dayOfWeek: new Date().toLocaleDateString("en-US", { weekday: "long" }) },
+        type: QuestionType.TIMESTAMP,
+        metadata: { fallback: true },
+      }
+    }
+
+    const randomLog = recentLogs[Math.floor(Math.random() * recentLogs.length)]
+    const logDate = new Date(randomLog.timestamp)
+    const dayOfWeek = logDate.toLocaleDateString("en-US", { weekday: "long" })
+
+    return {
+      question: `On which day of the week did you last interact with your capsules?`,
+      correctAnswer: { dayOfWeek },
+      type: QuestionType.TIMESTAMP,
+      metadata: {
+        targetTimestamp: randomLog.timestamp.toISOString(),
+        targetLogId: randomLog.id,
+      },
+    }
+  }
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/controllers/photo-submission.controller.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/controllers/photo-submission.controller.ts
@@ -1,0 +1,58 @@
+import { Controller, Get, Post, Body, Param, Query, ParseUUIDPipe, ParseIntPipe, ValidationPipe } from "@nestjs/common"
+import type { PhotoSubmissionService } from "../services/photo-submission.service"
+import type { PolaroidCapsuleService } from "../services/polaroid-capsule.service"
+import type { ReviewPhotoDto } from "../dto/review-photo.dto"
+import type { PhotoSubmission } from "../entities/photo-submission.entity"
+
+// Note: You'll need to implement your own authentication guard
+// import { AuthGuard } from '@nestjs/passport';
+// import { GetUser } from '../auth/get-user.decorator';
+
+@Controller("photo-submissions")
+// @UseGuards(AuthGuard())
+export class PhotoSubmissionController {
+  constructor(
+    private readonly photoSubmissionService: PhotoSubmissionService,
+    private readonly polaroidCapsuleService: PolaroidCapsuleService,
+  ) {}
+
+  @Get(":id")
+  async getSubmissionById(@Param('id') id: string): Promise<PhotoSubmission> {
+    return await this.photoSubmissionService.getSubmissionById(id)
+  }
+
+  @Get("user/:userId")
+  async getUserSubmissions(
+    @Param('userId', new ParseUUIDPipe()) userId: string,
+    @Query('limit', new ParseIntPipe({ optional: true })) limit?: number,
+  ): Promise<PhotoSubmission[]> {
+    return await this.photoSubmissionService.getUserSubmissions(userId, limit)
+  }
+
+  @Get("today/:userId")
+  async getTodaysSubmission(@Param('userId', ParseUUIDPipe) userId: string): Promise<PhotoSubmission | null> {
+    return await this.photoSubmissionService.getTodaysSubmission(userId)
+  }
+
+  @Get("pending")
+  // @UseGuards(AdminGuard) // Restrict to admins/reviewers
+  async getPendingSubmissions(
+    @Query('limit', new ParseIntPipe({ optional: true })) limit?: number,
+  ): Promise<PhotoSubmission[]> {
+    return await this.photoSubmissionService.getPendingSubmissions(limit)
+  }
+
+  @Post(":id/review")
+  // @UseGuards(AdminGuard) // Restrict to admins/reviewers
+  async reviewSubmission(
+    @Param('id') submissionId: string,
+    @Body(ValidationPipe) reviewDto: ReviewPhotoDto,
+  ): Promise<{ submission: PhotoSubmission; unlockedCapsules: any[] }> {
+    return await this.polaroidCapsuleService.reviewSubmission(
+      submissionId,
+      reviewDto.status,
+      reviewDto.reviewedBy,
+      reviewDto.rejectionReason,
+    )
+  }
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/controllers/polaroid-capsule.controller.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/controllers/polaroid-capsule.controller.ts
@@ -1,0 +1,43 @@
+import { Controller, Get, Post, Body, Param, Query, ParseUUIDPipe, ValidationPipe } from "@nestjs/common"
+import type { PolaroidCapsuleService } from "../services/polaroid-capsule.service"
+import type { CreatePolaroidCapsuleDto } from "../dto/create-polaroid-capsule.dto"
+import type { SubmitPhotoDto } from "../dto/submit-photo.dto"
+import type { PolaroidCapsuleResponseDto, SubmitPhotoResponseDto } from "../dto/polaroid-capsule-response.dto"
+
+// Note: You'll need to implement your own authentication guard
+// import { AuthGuard } from '@nestjs/passport';
+// import { GetUser } from '../auth/get-user.decorator';
+
+@Controller("polaroid-capsules")
+// @UseGuards(AuthGuard())
+export class PolaroidCapsuleController {
+  constructor(private readonly polaroidCapsuleService: PolaroidCapsuleService) {}
+
+  @Post()
+  async createCapsule(createCapsuleDto: CreatePolaroidCapsuleDto): Promise<PolaroidCapsuleResponseDto> {
+    return await this.polaroidCapsuleService.createCapsule(createCapsuleDto)
+  }
+
+  @Get()
+  async getUserCapsules(
+    @Query('userId') userId: string,
+  ): Promise<PolaroidCapsuleResponseDto[]> {
+    return await this.polaroidCapsuleService.getUserCapsules(userId)
+  }
+
+  @Get(":id")
+  async getCapsuleById(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('userId') userId: string,
+  ): Promise<PolaroidCapsuleResponseDto> {
+    return await this.polaroidCapsuleService.getCapsuleById(id, userId)
+  }
+
+  @Post("submit-photo")
+  async submitPhoto(
+    @Query('userId') userId: string,
+    @Body(ValidationPipe) submitPhotoDto: SubmitPhotoDto,
+  ): Promise<SubmitPhotoResponseDto> {
+    return await this.polaroidCapsuleService.submitPhoto(userId, submitPhotoDto)
+  }
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/controllers/theme.controller.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/controllers/theme.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Post, Body, Param, Query } from "@nestjs/common"
+import type { ThemeService } from "../services/theme.service"
+import type { CreatePhotoThemeDto } from "../dto/create-photo-theme.dto"
+import type { PhotoTheme } from "../entities/photo-theme.entity"
+import type { DailyTheme } from "../entities/daily-theme.entity"
+
+// Note: This controller should be restricted to admin users for theme creation
+// @UseGuards(AdminGuard)
+@Controller("photo-themes")
+export class ThemeController {
+  constructor(private readonly themeService: ThemeService) {}
+
+  @Post()
+  async createTheme(@Body() createThemeDto: CreatePhotoThemeDto): Promise<PhotoTheme> {
+    return await this.themeService.createTheme(createThemeDto)
+  }
+
+  @Get()
+  async getAllThemes(@Query('activeOnly') activeOnly: boolean = true): Promise<PhotoTheme[]> {
+    return await this.themeService.getAllThemes(activeOnly)
+  }
+
+  @Get("category/:category")
+  async getThemesByCategory(
+    @Param('category') category: string,
+    @Query('activeOnly') activeOnly: boolean = true,
+  ): Promise<PhotoTheme[]> {
+    return await this.themeService.getThemesByCategory(category, activeOnly)
+  }
+
+  @Get(":id")
+  async getThemeById(@Param('id') id: string): Promise<PhotoTheme> {
+    return await this.themeService.getThemeById(id)
+  }
+
+  @Get("daily/:userId")
+  async getDailyTheme(@Param('userId') userId: string): Promise<DailyTheme> {
+    return await this.themeService.getDailyTheme(userId)
+  }
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/cron/submission-cleanup.cron.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/cron/submission-cleanup.cron.ts
@@ -1,0 +1,145 @@
+import { Injectable, Inject } from "@nestjs/common"
+import { Cron, CronExpression } from "@nestjs/schedule"
+import type { Repository } from "typeorm"
+import { type PhotoSubmission, SubmissionStatus } from "../entities/photo-submission.entity"
+import { type PolaroidCapsule, PolaroidCapsuleStatus } from "../entities/polaroid-capsule.entity"
+import {
+  type PolaroidCapsuleInteractionLog,
+  PolaroidInteractionType,
+} from "../entities/polaroid-capsule-interaction-log.entity"
+import { Logger } from "@nestjs/common"
+import { LessThan } from "typeorm"
+
+@Injectable()
+export class SubmissionCleanupCron {
+  private readonly logger = new Logger(SubmissionCleanupCron.name);
+
+  constructor(
+    @Inject("PHOTO_SUBMISSION_REPOSITORY")
+    private photoSubmissionRepository: Repository<PhotoSubmission>,
+    @Inject("POLAROID_CAPSULE_REPOSITORY")
+    private polaroidCapsuleRepository: Repository<PolaroidCapsule>,
+    @Inject("POLAROID_CAPSULE_INTERACTION_LOG_REPOSITORY")
+    private interactionLogRepository: Repository<PolaroidCapsuleInteractionLog>,
+  ) {}
+
+  /**
+   * Auto-reject submissions that have been pending for too long
+   * This prevents submissions from staying in pending state indefinitely
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async autoRejectOldPendingSubmissions() {
+    this.logger.log("Checking for old pending submissions to auto-reject")
+
+    try {
+      const sevenDaysAgo = new Date()
+      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7)
+
+      const oldPendingSubmissions = await this.photoSubmissionRepository.find({
+        where: {
+          status: SubmissionStatus.PENDING,
+          submittedAt: LessThan(sevenDaysAgo),
+        },
+      })
+
+      this.logger.log(`Found ${oldPendingSubmissions.length} old pending submissions`)
+
+      for (const submission of oldPendingSubmissions) {
+        submission.status = SubmissionStatus.REJECTED
+        submission.rejectionReason = "Auto-rejected due to timeout (7 days without review)"
+        submission.reviewedBy = "system"
+        submission.reviewedAt = new Date()
+
+        await this.photoSubmissionRepository.save(submission)
+
+        // Log the auto-rejection
+        await this.logInteraction(submission.userId, null, PolaroidInteractionType.PHOTO_REJECTED, {
+          submissionId: submission.id,
+          reason: "auto_timeout",
+          reviewedBy: "system",
+        })
+
+        this.logger.log(`Auto-rejected submission ${submission.id}`)
+      }
+    } catch (error) {
+      this.logger.error("Error auto-rejecting old pending submissions:", error.stack)
+    }
+  }
+
+  /**
+   * Check for expired capsules and mark them as expired
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async checkExpiredCapsules() {
+    this.logger.log("Checking for expired polaroid capsules")
+
+    try {
+      const now = new Date()
+
+      const expiredCapsules = await this.polaroidCapsuleRepository.find({
+        where: {
+          status: PolaroidCapsuleStatus.LOCKED,
+          expiresAt: LessThan(now),
+        },
+      })
+
+      this.logger.log(`Found ${expiredCapsules.length} expired polaroid capsules`)
+
+      for (const capsule of expiredCapsules) {
+        capsule.status = PolaroidCapsuleStatus.EXPIRED
+        await this.polaroidCapsuleRepository.save(capsule)
+
+        // Log expiration
+        await this.logInteraction(capsule.userId, capsule.id, PolaroidInteractionType.EXPIRED, {
+          expiredAt: now,
+          originalExpiryDate: capsule.expiresAt,
+        })
+
+        this.logger.log(`Marked capsule ${capsule.id} as expired`)
+      }
+    } catch (error) {
+      this.logger.error("Error checking expired polaroid capsules:", error.stack)
+    }
+  }
+
+  /**
+   * Clean up old interaction logs to prevent database bloat
+   * Runs monthly to remove logs older than 1 year
+   */
+  @Cron(CronExpression.EVERY_1ST_DAY_OF_MONTH_AT_MIDNIGHT)
+  async cleanupOldLogs() {
+    this.logger.log("Starting monthly polaroid capsule log cleanup")
+
+    try {
+      const oneYearAgo = new Date()
+      oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1)
+
+      const result = await this.interactionLogRepository
+        .createQueryBuilder()
+        .delete()
+        .where("timestamp < :date", { date: oneYearAgo })
+        .execute()
+
+      this.logger.log(`Cleaned up ${result.affected} old polaroid capsule interaction logs`)
+    } catch (error) {
+      this.logger.error("Error during polaroid capsule log cleanup:", error.stack)
+    }
+  }
+
+  private async logInteraction(
+    userId: string,
+    capsuleId: string | null,
+    type: PolaroidInteractionType,
+    metadata?: Record<string, any>,
+  ): Promise<void> {
+    const log = this.interactionLogRepository.create({
+      userId,
+      capsuleId,
+      type,
+      submissionId: metadata?.submissionId,
+      metadata,
+    })
+
+    await this.interactionLogRepository.save(log)
+  }
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/cron/theme-rotation.cron.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/cron/theme-rotation.cron.ts
@@ -1,0 +1,96 @@
+import { Injectable, Inject } from "@nestjs/common"
+import { Cron, CronExpression } from "@nestjs/schedule"
+import type { Repository } from "typeorm"
+import type { DailyTheme } from "../entities/daily-theme.entity"
+import type { PhotoTheme } from "../entities/photo-theme.entity"
+import { Logger } from "@nestjs/common"
+
+@Injectable()
+export class ThemeRotationCron {
+  private readonly logger = new Logger(ThemeRotationCron.name);
+
+  constructor(
+    @Inject("DailyThemeRepository")
+    private dailyThemeRepository: Repository<DailyTheme>,
+    @Inject("PhotoThemeRepository")
+    private photoThemeRepository: Repository<PhotoTheme>,
+  ) {}
+
+  /**
+   * Clean up old daily themes to prevent database bloat
+   * Runs daily to remove themes older than 30 days
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_2AM)
+  async cleanupOldDailyThemes() {
+    this.logger.log("Starting daily theme cleanup")
+
+    try {
+      const thirtyDaysAgo = new Date()
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+
+      const result = await this.dailyThemeRepository
+        .createQueryBuilder()
+        .delete()
+        .where("date < :date", { date: thirtyDaysAgo })
+        .execute()
+
+      this.logger.log(`Cleaned up ${result.affected} old daily themes`)
+    } catch (error) {
+      this.logger.error("Error during daily theme cleanup:", error.stack)
+    }
+  }
+
+  /**
+   * Reset theme usage counts weekly to ensure fair rotation
+   * This prevents popular themes from being overused
+   */
+  @Cron(CronExpression.EVERY_WEEK)
+  async resetThemeUsageCounts() {
+    this.logger.log("Resetting theme usage counts")
+
+    try {
+      const result = await this.photoThemeRepository.createQueryBuilder().update().set({ usageCount: 0 }).execute()
+
+      this.logger.log(`Reset usage counts for ${result.affected} themes`)
+    } catch (error) {
+      this.logger.error("Error resetting theme usage counts:", error.stack)
+    }
+  }
+
+  /**
+   * Deactivate themes that haven't been used in a long time
+   * This helps maintain a fresh rotation of themes
+   */
+  @Cron(CronExpression.EVERY_1ST_DAY_OF_MONTH_AT_MIDNIGHT)
+  async deactivateUnusedThemes() {
+    this.logger.log("Checking for unused themes to deactivate")
+
+    try {
+      // Find themes that haven't been assigned in the last 60 days
+      const sixtyDaysAgo = new Date()
+      sixtyDaysAgo.setDate(sixtyDaysAgo.getDate() - 60)
+
+      const unusedThemes = await this.photoThemeRepository
+        .createQueryBuilder("theme")
+        .leftJoin("daily_themes", "dt", "dt.theme_id = theme.id")
+        .where("theme.is_active = :isActive", { isActive: true })
+        .andWhere("(dt.created_at IS NULL OR dt.created_at < :date)", { date: sixtyDaysAgo })
+        .getMany()
+
+      if (unusedThemes.length > 0) {
+        await this.photoThemeRepository
+          .createQueryBuilder()
+          .update()
+          .set({ isActive: false })
+          .whereInIds(unusedThemes.map((theme) => theme.id))
+          .execute()
+
+        this.logger.log(`Deactivated ${unusedThemes.length} unused themes`)
+      } else {
+        this.logger.log("No unused themes found to deactivate")
+      }
+    } catch (error) {
+      this.logger.error("Error deactivating unused themes:", error.stack)
+    }
+  }
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/dto/create-photo-theme.dto.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/dto/create-photo-theme.dto.ts
@@ -1,0 +1,24 @@
+import { IsString, IsOptional, IsEnum, IsArray, IsBoolean, IsObject } from "class-validator"
+import { ThemeCategory } from "../entities/photo-theme.entity"
+
+export class CreatePhotoThemeDto {
+  @IsString()
+  name: string
+
+  @IsString()
+  description: string
+
+  @IsEnum(ThemeCategory)
+  category: ThemeCategory
+
+  @IsArray()
+  keywords: string[]
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/dto/create-polaroid-capsule.dto.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/dto/create-polaroid-capsule.dto.ts
@@ -1,0 +1,38 @@
+import { IsString, IsOptional, IsEnum, IsDateString, IsObject, IsNumber, Min, Max } from "class-validator"
+import { PolaroidCapsuleType, ValidationMethod } from "../entities/polaroid-capsule.entity"
+
+export class CreatePolaroidCapsuleDto {
+  @IsString()
+  title: string
+
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @IsObject()
+  content: Record<string, any>
+
+  @IsEnum(PolaroidCapsuleType)
+  type: PolaroidCapsuleType
+
+  @IsString()
+  userId: string
+
+  @IsOptional()
+  @IsEnum(ValidationMethod)
+  validationMethod?: ValidationMethod
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0.1)
+  @Max(1.0)
+  confidenceThreshold?: number
+
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/dto/polaroid-capsule-response.dto.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/dto/polaroid-capsule-response.dto.ts
@@ -1,0 +1,58 @@
+import type { PolaroidCapsuleStatus, PolaroidCapsuleType, ValidationMethod } from "../entities/polaroid-capsule.entity"
+import type { ThemeCategory } from "../entities/photo-theme.entity"
+import type { SubmissionStatus } from "../entities/photo-submission.entity"
+
+export class PhotoThemeResponseDto {
+  id: string
+  name: string
+  description: string
+  category: ThemeCategory
+  keywords: string[]
+}
+
+export class DailyThemeResponseDto {
+  id: string
+  date: Date
+  theme: PhotoThemeResponseDto
+}
+
+export class PhotoSubmissionResponseDto {
+  id: string
+  photoUrl: string
+  thumbnailUrl?: string
+  caption?: string
+  status: SubmissionStatus
+  confidenceScore?: number
+  rejectionReason?: string
+  submittedAt: Date
+  reviewedAt?: Date
+  dailyTheme: DailyThemeResponseDto
+}
+
+export class PolaroidCapsuleResponseDto {
+  id: string
+  title: string
+  description?: string
+  content?: Record<string, any>
+  type: PolaroidCapsuleType
+  status: PolaroidCapsuleStatus
+  userId: string
+  validationMethod: ValidationMethod
+  confidenceThreshold: number
+  unlockedBySubmissionId?: string
+  unlockedAt?: Date
+  expiresAt?: Date
+  metadata?: Record<string, any>
+  createdAt: Date
+  updatedAt: Date
+  todaysTheme?: DailyThemeResponseDto
+  todaysSubmission?: PhotoSubmissionResponseDto
+}
+
+export class SubmitPhotoResponseDto {
+  success: boolean
+  message: string
+  submission: PhotoSubmissionResponseDto
+  capsuleUnlocked: boolean
+  unlockedCapsule?: PolaroidCapsuleResponseDto
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/dto/review-photo.dto.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/dto/review-photo.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, IsOptional, IsEnum, IsObject } from "class-validator"
+import { SubmissionStatus } from "../entities/photo-submission.entity"
+
+export class ReviewPhotoDto {
+  @IsEnum(SubmissionStatus)
+  status: SubmissionStatus
+
+  @IsOptional()
+  @IsString()
+  rejectionReason?: string
+
+  @IsString()
+  reviewedBy: string
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/dto/submit-photo.dto.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/dto/submit-photo.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, IsOptional, IsObject } from "class-validator"
+
+export class SubmitPhotoDto {
+  @IsString()
+  photoUrl: string
+
+  @IsOptional()
+  @IsString()
+  thumbnailUrl?: string
+
+  @IsOptional()
+  @IsString()
+  caption?: string
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/entities/daily-theme.entity.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/entities/daily-theme.entity.ts
@@ -1,0 +1,28 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, JoinColumn, Index } from "typeorm"
+import { PhotoTheme } from "./photo-theme.entity"
+
+@Entity("daily_themes")
+@Index(["date", "userId"], { unique: true })
+export class DailyTheme {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "uuid" })
+  themeId: string
+
+  @Column({ type: "date" })
+  date: Date
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @ManyToOne(() => PhotoTheme)
+  @JoinColumn({ name: "themeId" })
+  theme: PhotoTheme
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/entities/photo-submission.entity.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/entities/photo-submission.entity.ts
@@ -1,0 +1,66 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, JoinColumn, Index } from "typeorm"
+import { DailyTheme } from "./daily-theme.entity"
+
+export enum SubmissionStatus {
+  PENDING = "pending",
+  APPROVED = "approved",
+  REJECTED = "rejected",
+}
+
+@Entity("photo_submissions")
+export class PhotoSubmission {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  @Index()
+  userId: string
+
+  @Column({ type: "uuid" })
+  dailyThemeId: string
+
+  @Column({ type: "varchar", length: 255 })
+  photoUrl: string
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  thumbnailUrl: string
+
+  @Column({ type: "text", nullable: true })
+  caption: string
+
+  @Column({
+    type: "enum",
+    enum: SubmissionStatus,
+    default: SubmissionStatus.PENDING,
+  })
+  status: SubmissionStatus
+
+  @Column({ type: "jsonb", nullable: true })
+  detectionResults: Record<string, any>
+
+  @Column({ type: "float", nullable: true })
+  confidenceScore: number
+
+  @Column({ type: "text", nullable: true })
+  rejectionReason: string
+
+  @Column({ type: "uuid", nullable: true })
+  reviewedBy: string
+
+  @Column({ type: "timestamp", nullable: true })
+  reviewedAt: Date
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @CreateDateColumn()
+  submittedAt: Date
+
+  @Column({ type: "date" })
+  @Index()
+  submissionDate: Date
+
+  @ManyToOne(() => DailyTheme)
+  @JoinColumn({ name: "dailyThemeId" })
+  dailyTheme: DailyTheme
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/entities/photo-theme.entity.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/entities/photo-theme.entity.ts
@@ -1,0 +1,46 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from "typeorm"
+
+export enum ThemeCategory {
+  COLOR = "color",
+  OBJECT = "object",
+  EMOTION = "emotion",
+  NATURE = "nature",
+  ABSTRACT = "abstract",
+  ACTIVITY = "activity",
+}
+
+@Entity("photo_themes")
+export class PhotoTheme {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "varchar", length: 255 })
+  name: string
+
+  @Column({ type: "text" })
+  description: string
+
+  @Column({
+    type: "enum",
+    enum: ThemeCategory,
+  })
+  category: ThemeCategory
+
+  @Column({ type: "text", array: true })
+  keywords: string[]
+
+  @Column({ type: "boolean", default: true })
+  isActive: boolean
+
+  @Column({ type: "int", default: 0 })
+  usageCount: number
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/entities/polaroid-capsule-interaction-log.entity.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/entities/polaroid-capsule-interaction-log.entity.ts
@@ -1,0 +1,59 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, JoinColumn } from "typeorm"
+import { PolaroidCapsule } from "./polaroid-capsule.entity"
+
+export enum PolaroidInteractionType {
+  CREATED = "created",
+  VIEWED = "viewed",
+  THEME_ASSIGNED = "theme_assigned",
+  PHOTO_SUBMITTED = "photo_submitted",
+  PHOTO_APPROVED = "photo_approved",
+  PHOTO_REJECTED = "photo_rejected",
+  UNLOCKED = "unlocked",
+  EXPIRED = "expired",
+}
+
+@Entity("polaroid_capsule_interaction_logs")
+export class PolaroidCapsuleInteractionLog {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "uuid" })
+  capsuleId: string
+
+  @Column({
+    type: "enum",
+    enum: PolaroidInteractionType,
+  })
+  type: PolaroidInteractionType
+
+  @Column({ type: "uuid", nullable: true })
+  themeId: string
+
+  @Column({ type: "uuid", nullable: true })
+  submissionId: string
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  userAgent: string
+
+  @Column({ type: "inet", nullable: true })
+  ipAddress: string
+
+  @CreateDateColumn()
+  timestamp: Date
+
+  @ManyToOne(
+    () => PolaroidCapsule,
+    (capsule) => capsule.interactionLogs,
+    {
+      onDelete: "CASCADE",
+    },
+  )
+  @JoinColumn({ name: "capsuleId" })
+  capsule: PolaroidCapsule
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/entities/polaroid-capsule.entity.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/entities/polaroid-capsule.entity.ts
@@ -1,0 +1,88 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from "typeorm"
+import { PolaroidCapsuleInteractionLog } from "./polaroid-capsule-interaction-log.entity"
+
+export enum PolaroidCapsuleStatus {
+  LOCKED = "locked",
+  UNLOCKED = "unlocked",
+  EXPIRED = "expired",
+}
+
+export enum PolaroidCapsuleType {
+  TEXT = "text",
+  IMAGE = "image",
+  VIDEO = "video",
+  AUDIO = "audio",
+  MIXED = "mixed",
+}
+
+export enum ValidationMethod {
+  MANUAL = "manual",
+  AUTOMATIC = "automatic",
+  HYBRID = "hybrid",
+}
+
+@Entity("polaroid_capsules")
+export class PolaroidCapsule {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "varchar", length: 255 })
+  title: string
+
+  @Column({ type: "text", nullable: true })
+  description: string
+
+  @Column({ type: "jsonb" })
+  content: Record<string, any>
+
+  @Column({
+    type: "enum",
+    enum: PolaroidCapsuleType,
+    default: PolaroidCapsuleType.TEXT,
+  })
+  type: PolaroidCapsuleType
+
+  @Column({
+    type: "enum",
+    enum: PolaroidCapsuleStatus,
+    default: PolaroidCapsuleStatus.LOCKED,
+  })
+  status: PolaroidCapsuleStatus
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({
+    type: "enum",
+    enum: ValidationMethod,
+    default: ValidationMethod.MANUAL,
+  })
+  validationMethod: ValidationMethod
+
+  @Column({ type: "float", default: 0.7 })
+  confidenceThreshold: number
+
+  @Column({ type: "uuid", nullable: true })
+  unlockedBySubmissionId: string
+
+  @Column({ type: "timestamp", nullable: true })
+  unlockedAt: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  expiresAt: Date
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+
+  @OneToMany(
+    () => PolaroidCapsuleInteractionLog,
+    (log) => log.capsule,
+  )
+  interactionLogs: PolaroidCapsuleInteractionLog[]
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/polaroid-capsule.module.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/polaroid-capsule.module.ts
@@ -1,0 +1,26 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { HttpModule } from "@nestjs/axios"
+import { PolaroidCapsuleController } from "./controllers/polaroid-capsule.controller"
+import { ThemeController } from "./controllers/theme.controller"
+import { PhotoSubmissionController } from "./controllers/photo-submission.controller"
+import { PolaroidCapsuleService } from "./services/polaroid-capsule.service"
+import { ThemeService } from "./services/theme.service"
+import { PhotoSubmissionService } from "./services/photo-submission.service"
+import { ObjectDetectionService } from "./services/object-detection.service"
+import { PolaroidCapsule } from "./entities/polaroid-capsule.entity"
+import { PhotoTheme } from "./entities/photo-theme.entity"
+import { DailyTheme } from "./entities/daily-theme.entity"
+import { PhotoSubmission } from "./entities/photo-submission.entity"
+import { PolaroidCapsuleInteractionLog } from "./entities/polaroid-capsule-interaction-log.entity"
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([PolaroidCapsule, PhotoTheme, DailyTheme, PhotoSubmission, PolaroidCapsuleInteractionLog]),
+    HttpModule,
+  ],
+  controllers: [PolaroidCapsuleController, ThemeController, PhotoSubmissionController],
+  providers: [PolaroidCapsuleService, ThemeService, PhotoSubmissionService, ObjectDetectionService],
+  exports: [PolaroidCapsuleService, ThemeService, PhotoSubmissionService],
+})
+export class PolaroidCapsuleModule {}

--- a/apps/capsulelabs-api/src/polaroid-capsule/services/object-detection.service.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/services/object-detection.service.ts
@@ -1,0 +1,192 @@
+import { Injectable } from "@nestjs/common"
+import type { ConfigService } from "@nestjs/config"
+import type { HttpService } from "@nestjs/axios"
+import { firstValueFrom } from "rxjs"
+
+@Injectable()
+export class ObjectDetectionService {
+  private readonly apiKey: string
+  private readonly apiEndpoint: string
+  private readonly useExternalApi: boolean
+
+  constructor(
+    private configService: ConfigService,
+    private httpService: HttpService,
+  ) {
+    this.apiKey = this.configService.get<string>("VISION_API_KEY", "")
+    this.apiEndpoint = this.configService.get<string>("VISION_API_ENDPOINT", "")
+    this.useExternalApi = this.configService.get<boolean>("USE_EXTERNAL_VISION_API", false)
+  }
+
+  /**
+   * Detect objects in an image using external API or mock implementation
+   */
+  async detectObjects(imageUrl: string): Promise<{
+    labels: string[]
+    colors: string[]
+    confidence: number
+    rawResponse: any
+  }> {
+    if (this.useExternalApi && this.apiKey && this.apiEndpoint) {
+      return await this.detectObjectsWithExternalApi(imageUrl)
+    } else {
+      return await this.mockObjectDetection(imageUrl)
+    }
+  }
+
+  /**
+   * Check if an image matches a theme based on keywords
+   */
+  matchImageToTheme(
+    detectionResults: { labels: string[]; colors: string[] },
+    themeKeywords: string[],
+  ): { isMatch: boolean; confidence: number; matchedKeywords: string[] } {
+    const allDetectedTerms = [...detectionResults.labels, ...detectionResults.colors].map((term) => term.toLowerCase())
+    const normalizedKeywords = themeKeywords.map((keyword) => keyword.toLowerCase())
+
+    const matchedKeywords = normalizedKeywords.filter((keyword) => {
+      return allDetectedTerms.some((term) => term.includes(keyword) || keyword.includes(term))
+    })
+
+    const confidence = matchedKeywords.length > 0 ? matchedKeywords.length / normalizedKeywords.length : 0
+    const isMatch = confidence > 0
+
+    return {
+      isMatch,
+      confidence,
+      matchedKeywords,
+    }
+  }
+
+  /**
+   * Detect objects using an external API like Google Cloud Vision
+   */
+  private async detectObjectsWithExternalApi(imageUrl: string): Promise<{
+    labels: string[]
+    colors: string[]
+    confidence: number
+    rawResponse: any
+  }> {
+    try {
+      const response = await firstValueFrom(
+        this.httpService.post(
+          this.apiEndpoint,
+          {
+            requests: [
+              {
+                image: {
+                  source: {
+                    imageUri: imageUrl,
+                  },
+                },
+                features: [
+                  { type: "LABEL_DETECTION", maxResults: 10 },
+                  { type: "IMAGE_PROPERTIES", maxResults: 5 },
+                ],
+              },
+            ],
+          },
+          {
+            headers: {
+              Authorization: `Bearer ${this.apiKey}`,
+              "Content-Type": "application/json",
+            },
+          },
+        ),
+      )
+
+      const data = response.data
+      const labels = data.responses[0]?.labelAnnotations?.map((label: any) => label.description) || []
+      const colors =
+        data.responses[0]?.imagePropertiesAnnotation?.dominantColors?.colors?.map((color: any) =>
+          this.rgbToColorName(color.color.red, color.color.green, color.color.blue),
+        ) || []
+
+      // Calculate average confidence from label annotations
+      const confidence =
+        data.responses[0]?.labelAnnotations?.reduce((sum: number, label: any) => sum + label.score, 0) /
+          data.responses[0]?.labelAnnotations?.length || 0
+
+      return {
+        labels,
+        colors,
+        confidence,
+        rawResponse: data,
+      }
+    } catch (error) {
+      console.error("Error calling external vision API:", error)
+      return this.mockObjectDetection(imageUrl)
+    }
+  }
+
+  /**
+   * Mock object detection for development or when external API is not available
+   */
+  private async mockObjectDetection(imageUrl: string): Promise<{
+    labels: string[]
+    colors: string[]
+    confidence: number
+    rawResponse: any
+  }> {
+    // Extract potential keywords from the image URL
+    const urlParts = imageUrl.toLowerCase().split(/[/.-_]/)
+    const potentialKeywords = urlParts.filter(
+      (part) => part.length > 3 && !part.match(/^(http|https|www|com|jpg|png|jpeg)$/),
+    )
+
+    // Generate mock labels based on URL parts or use generic labels
+    const mockLabels = potentialKeywords.length > 0 ? potentialKeywords.slice(0, 5) : ["object", "photo", "image"]
+
+    // Generate mock colors
+    const mockColors = ["blue", "red", "green", "yellow", "white"]
+    const selectedColors = mockColors.slice(0, Math.floor(Math.random() * 3) + 1)
+
+    return {
+      labels: mockLabels,
+      colors: selectedColors,
+      confidence: 0.7 + Math.random() * 0.3, // Random confidence between 0.7 and 1.0
+      rawResponse: {
+        mock: true,
+        imageUrl,
+        labels: mockLabels,
+        colors: selectedColors,
+      },
+    }
+  }
+
+  /**
+   * Convert RGB values to color name
+   */
+  private rgbToColorName(r: number, g: number, b: number): string {
+    // Simple color naming logic
+    const colors = [
+      { name: "red", r: 255, g: 0, b: 0 },
+      { name: "green", r: 0, g: 255, b: 0 },
+      { name: "blue", r: 0, g: 0, b: 255 },
+      { name: "yellow", r: 255, g: 255, b: 0 },
+      { name: "cyan", r: 0, g: 255, b: 255 },
+      { name: "magenta", r: 255, g: 0, b: 255 },
+      { name: "white", r: 255, g: 255, b: 255 },
+      { name: "black", r: 0, g: 0, b: 0 },
+      { name: "orange", r: 255, g: 165, b: 0 },
+      { name: "purple", r: 128, g: 0, b: 128 },
+      { name: "brown", r: 165, g: 42, b: 42 },
+      { name: "pink", r: 255, g: 192, b: 203 },
+      { name: "gray", r: 128, g: 128, b: 128 },
+    ]
+
+    // Find the closest color by Euclidean distance
+    let minDistance = Number.POSITIVE_INFINITY
+    let closestColor = "unknown"
+
+    for (const color of colors) {
+      const distance = Math.sqrt(Math.pow(r - color.r, 2) + Math.pow(g - color.g, 2) + Math.pow(b - color.b, 2))
+      if (distance < minDistance) {
+        minDistance = distance
+        closestColor = color.name
+      }
+    }
+
+    return closestColor
+  }
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/services/photo-submission.service.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/services/photo-submission.service.ts
@@ -1,0 +1,140 @@
+import { Injectable, BadRequestException, NotFoundException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { PhotoSubmission, SubmissionStatus } from "../entities/photo-submission.entity"
+import type { SubmitPhotoDto } from "../dto/submit-photo.dto"
+import type { ReviewPhotoDto } from "../dto/review-photo.dto"
+import type { ThemeService } from "./theme.service"
+import type { ObjectDetectionService } from "./object-detection.service"
+
+@Injectable()
+export class PhotoSubmissionService {
+  constructor(
+    @InjectRepository(PhotoSubmission)
+    private photoSubmissionRepository: Repository<PhotoSubmission>,
+    private themeService: ThemeService,
+    private objectDetectionService: ObjectDetectionService,
+  ) {}
+
+  async submitPhoto(userId: string, submitPhotoDto: SubmitPhotoDto): Promise<PhotoSubmission> {
+    // Get today's theme for the user
+    const dailyTheme = await this.themeService.getDailyTheme(userId)
+
+    // Check if user already submitted a photo today
+    const existingSubmission = await this.getTodaysSubmission(userId)
+    if (existingSubmission) {
+      throw new BadRequestException("You have already submitted a photo today")
+    }
+
+    // Get today's date
+    const today = new Date()
+    const submissionDate = new Date(today.getFullYear(), today.getMonth(), today.getDate())
+
+    // Create submission
+    const submission = this.photoSubmissionRepository.create({
+      userId,
+      dailyThemeId: dailyTheme.id,
+      photoUrl: submitPhotoDto.photoUrl,
+      thumbnailUrl: submitPhotoDto.thumbnailUrl,
+      caption: submitPhotoDto.caption,
+      metadata: submitPhotoDto.metadata,
+      submissionDate,
+    })
+
+    // If the photo URL is available, perform object detection
+    if (submission.photoUrl) {
+      try {
+        const detectionResults = await this.objectDetectionService.detectObjects(submission.photoUrl)
+        submission.detectionResults = detectionResults
+
+        // Match detected objects with theme keywords
+        const matchResult = this.objectDetectionService.matchImageToTheme(
+          {
+            labels: detectionResults.labels,
+            colors: detectionResults.colors,
+          },
+          dailyTheme.theme.keywords,
+        )
+
+        submission.confidenceScore = matchResult.confidence
+
+        // Auto-approve if confidence is high enough (this threshold can be configurable)
+        if (matchResult.confidence >= 0.7) {
+          submission.status = SubmissionStatus.APPROVED
+          submission.reviewedAt = new Date()
+          submission.reviewedBy = "system"
+        }
+      } catch (error) {
+        console.error("Error during object detection:", error)
+        // Continue with submission even if object detection fails
+      }
+    }
+
+    return await this.photoSubmissionRepository.save(submission)
+  }
+
+  async reviewSubmission(submissionId: string, reviewDto: ReviewPhotoDto): Promise<PhotoSubmission> {
+    const submission = await this.photoSubmissionRepository.findOne({
+      where: { id: submissionId },
+    })
+
+    if (!submission) {
+      throw new NotFoundException("Photo submission not found")
+    }
+
+    submission.status = reviewDto.status
+    submission.rejectionReason = reviewDto.rejectionReason
+    submission.reviewedBy = reviewDto.reviewedBy
+    submission.reviewedAt = new Date()
+
+    if (reviewDto.metadata) {
+      submission.metadata = { ...submission.metadata, ...reviewDto.metadata }
+    }
+
+    return await this.photoSubmissionRepository.save(submission)
+  }
+
+  async getSubmissionById(id: string): Promise<PhotoSubmission> {
+    const submission = await this.photoSubmissionRepository.findOne({
+      where: { id },
+      relations: ["dailyTheme", "dailyTheme.theme"],
+    })
+
+    if (!submission) {
+      throw new NotFoundException("Photo submission not found")
+    }
+
+    return submission
+  }
+
+  async getUserSubmissions(userId: string, limit = 30): Promise<PhotoSubmission[]> {
+    return await this.photoSubmissionRepository.find({
+      where: { userId },
+      relations: ["dailyTheme", "dailyTheme.theme"],
+      order: { submittedAt: "DESC" },
+      take: limit,
+    })
+  }
+
+  async getTodaysSubmission(userId: string): Promise<PhotoSubmission | null> {
+    const today = new Date()
+    const submissionDate = new Date(today.getFullYear(), today.getMonth(), today.getDate())
+
+    return await this.photoSubmissionRepository.findOne({
+      where: {
+        userId,
+        submissionDate,
+      },
+      relations: ["dailyTheme", "dailyTheme.theme"],
+    })
+  }
+
+  async getPendingSubmissions(limit = 50): Promise<PhotoSubmission[]> {
+    return await this.photoSubmissionRepository.find({
+      where: { status: SubmissionStatus.PENDING },
+      relations: ["dailyTheme", "dailyTheme.theme"],
+      order: { submittedAt: "ASC" },
+      take: limit,
+    })
+  }
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/services/polaroid-capsule.service.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/services/polaroid-capsule.service.ts
@@ -1,0 +1,307 @@
+import { Injectable, NotFoundException, BadRequestException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { PolaroidCapsule, PolaroidCapsuleStatus } from "../entities/polaroid-capsule.entity"
+import {
+  PolaroidCapsuleInteractionLog,
+  PolaroidInteractionType,
+} from "../entities/polaroid-capsule-interaction-log.entity"
+import { SubmissionStatus } from "../entities/photo-submission.entity"
+import type { CreatePolaroidCapsuleDto } from "../dto/create-polaroid-capsule.dto"
+import type { SubmitPhotoDto } from "../dto/submit-photo.dto"
+import type {
+  PolaroidCapsuleResponseDto,
+  SubmitPhotoResponseDto,
+  DailyThemeResponseDto,
+  PhotoSubmissionResponseDto,
+} from "../dto/polaroid-capsule-response.dto"
+import type { ThemeService } from "./theme.service"
+import type { PhotoSubmissionService } from "./photo-submission.service"
+
+@Injectable()
+export class PolaroidCapsuleService {
+  private polaroidCapsuleRepository: Repository<PolaroidCapsule>
+  private interactionLogRepository: Repository<PolaroidCapsuleInteractionLog>
+
+  constructor(
+    @InjectRepository(PolaroidCapsule)
+    polaroidCapsuleRepository: Repository<PolaroidCapsule>,
+    @InjectRepository(PolaroidCapsuleInteractionLog)
+    interactionLogRepository: Repository<PolaroidCapsuleInteractionLog>,
+    private themeService: ThemeService,
+    private photoSubmissionService: PhotoSubmissionService,
+  ) {
+    this.polaroidCapsuleRepository = polaroidCapsuleRepository
+    this.interactionLogRepository = interactionLogRepository
+  }
+
+  async createCapsule(createCapsuleDto: CreatePolaroidCapsuleDto): Promise<PolaroidCapsuleResponseDto> {
+    const capsule = this.polaroidCapsuleRepository.create({
+      ...createCapsuleDto,
+      validationMethod: createCapsuleDto.validationMethod || "manual",
+      confidenceThreshold: createCapsuleDto.confidenceThreshold || 0.7,
+      expiresAt: createCapsuleDto.expiresAt ? new Date(createCapsuleDto.expiresAt) : null,
+    })
+
+    const savedCapsule = await this.polaroidCapsuleRepository.save(capsule)
+
+    // Log the creation
+    await this.logInteraction(savedCapsule.userId, savedCapsule.id, PolaroidInteractionType.CREATED, {
+      capsuleType: savedCapsule.type,
+      validationMethod: savedCapsule.validationMethod,
+    })
+
+    return this.mapToResponseDto(savedCapsule)
+  }
+
+  async getCapsuleById(id: string, userId: string): Promise<PolaroidCapsuleResponseDto> {
+    const capsule = await this.polaroidCapsuleRepository.findOne({
+      where: { id, userId },
+    })
+
+    if (!capsule) {
+      throw new NotFoundException("Polaroid capsule not found")
+    }
+
+    // Log the view
+    await this.logInteraction(userId, id, PolaroidInteractionType.VIEWED)
+
+    return this.mapToResponseDto(capsule)
+  }
+
+  async getUserCapsules(userId: string): Promise<PolaroidCapsuleResponseDto[]> {
+    const capsules = await this.polaroidCapsuleRepository.find({
+      where: { userId },
+      order: { createdAt: "DESC" },
+    })
+
+    const results: PolaroidCapsuleResponseDto[] = []
+
+    for (const capsule of capsules) {
+      results.push(await this.mapToResponseDto(capsule))
+    }
+
+    return results
+  }
+
+  async submitPhoto(userId: string, submitPhotoDto: SubmitPhotoDto): Promise<SubmitPhotoResponseDto> {
+    try {
+      // Submit the photo
+      const submission = await this.photoSubmissionService.submitPhoto(userId, submitPhotoDto)
+
+      // Get today's theme
+      const dailyTheme = await this.themeService.getDailyTheme(userId)
+
+      // Log the submission
+      await this.logInteraction(userId, null, PolaroidInteractionType.PHOTO_SUBMITTED, {
+        submissionId: submission.id,
+        themeId: dailyTheme.themeId,
+      })
+
+      let capsuleUnlocked = false
+      let unlockedCapsule: PolaroidCapsule | null = null
+
+      // If submission was auto-approved, check for capsules to unlock
+      if (submission.status === SubmissionStatus.APPROVED) {
+        // Get all user's locked polaroid capsules
+        const capsules = await this.polaroidCapsuleRepository.find({
+          where: { userId, status: PolaroidCapsuleStatus.LOCKED },
+        })
+
+        // Check each capsule to see if it can be unlocked
+        for (const capsule of capsules) {
+          // For automatic validation, check if confidence score meets threshold
+          if (
+            (capsule.validationMethod === "automatic" || capsule.validationMethod === "hybrid") &&
+            submission.confidenceScore &&
+            submission.confidenceScore >= capsule.confidenceThreshold
+          ) {
+            await this.unlockCapsule(capsule, submission.id)
+            capsuleUnlocked = true
+            unlockedCapsule = capsule
+
+            // Log the approval
+            await this.logInteraction(userId, capsule.id, PolaroidInteractionType.PHOTO_APPROVED, {
+              submissionId: submission.id,
+              confidenceScore: submission.confidenceScore,
+            })
+          }
+        }
+      }
+
+      // Prepare response
+      const response: SubmitPhotoResponseDto = {
+        success: true,
+        message: capsuleUnlocked
+          ? "Photo submitted successfully and capsule unlocked!"
+          : submission.status === SubmissionStatus.APPROVED
+            ? "Photo approved automatically but no capsules were unlocked."
+            : "Photo submitted successfully and pending review.",
+        submission: this.mapSubmissionToResponseDto(submission, dailyTheme),
+        capsuleUnlocked,
+      }
+
+      if (unlockedCapsule) {
+        response.unlockedCapsule = await this.mapToResponseDto(unlockedCapsule)
+      }
+
+      return response
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error
+      }
+      throw new BadRequestException("Failed to submit photo")
+    }
+  }
+
+  async reviewSubmission(
+    submissionId: string,
+    status: SubmissionStatus,
+    reviewedBy: string,
+    rejectionReason?: string,
+  ): Promise<{ submission: any; unlockedCapsules: PolaroidCapsule[] }> {
+    // Review the submission
+    const submission = await this.photoSubmissionService.reviewSubmission(submissionId, {
+      status,
+      reviewedBy,
+      rejectionReason,
+    })
+
+    const unlockedCapsules: PolaroidCapsule[] = []
+
+    // If approved, check for capsules to unlock
+    if (status === SubmissionStatus.APPROVED) {
+      // Get all user's locked polaroid capsules
+      const capsules = await this.polaroidCapsuleRepository.find({
+        where: { userId: submission.userId, status: PolaroidCapsuleStatus.LOCKED },
+      })
+
+      // Unlock all capsules that use manual validation
+      for (const capsule of capsules) {
+        if (capsule.validationMethod === "manual" || capsule.validationMethod === "hybrid") {
+          await this.unlockCapsule(capsule, submissionId)
+          unlockedCapsules.push(capsule)
+
+          // Log the approval
+          await this.logInteraction(submission.userId, capsule.id, PolaroidInteractionType.PHOTO_APPROVED, {
+            submissionId,
+            reviewedBy,
+          })
+        }
+      }
+    } else if (status === SubmissionStatus.REJECTED) {
+      // Log the rejection for all capsules
+      const capsules = await this.polaroidCapsuleRepository.find({
+        where: { userId: submission.userId, status: PolaroidCapsuleStatus.LOCKED },
+      })
+
+      for (const capsule of capsules) {
+        await this.logInteraction(submission.userId, capsule.id, PolaroidInteractionType.PHOTO_REJECTED, {
+          submissionId,
+          reviewedBy,
+          rejectionReason,
+        })
+      }
+    }
+
+    return { submission, unlockedCapsules }
+  }
+
+  private async unlockCapsule(capsule: PolaroidCapsule, submissionId: string): Promise<void> {
+    capsule.status = PolaroidCapsuleStatus.UNLOCKED
+    capsule.unlockedAt = new Date()
+    capsule.unlockedBySubmissionId = submissionId
+    await this.polaroidCapsuleRepository.save(capsule)
+
+    // Log the unlock
+    await this.logInteraction(capsule.userId, capsule.id, PolaroidInteractionType.UNLOCKED, {
+      submissionId,
+    })
+  }
+
+  private async logInteraction(
+    userId: string,
+    capsuleId: string | null,
+    type: PolaroidInteractionType,
+    metadata?: Record<string, any>,
+  ): Promise<void> {
+    const log = this.interactionLogRepository.create({
+      userId,
+      capsuleId,
+      type,
+      themeId: metadata?.themeId,
+      submissionId: metadata?.submissionId,
+      metadata,
+    })
+
+    await this.interactionLogRepository.save(log)
+  }
+
+  private async mapToResponseDto(capsule: PolaroidCapsule): Promise<PolaroidCapsuleResponseDto> {
+    // Get today's theme for the user
+    let todaysTheme = null
+    let todaysSubmission = null
+
+    try {
+      const dailyTheme = await this.themeService.getDailyTheme(capsule.userId)
+      todaysTheme = this.mapThemeToResponseDto(dailyTheme)
+
+      // Get today's submission if it exists
+      const submission = await this.photoSubmissionService.getTodaysSubmission(capsule.userId)
+      if (submission) {
+        todaysSubmission = this.mapSubmissionToResponseDto(submission, dailyTheme)
+      }
+    } catch (error) {
+      console.error("Error fetching today's theme or submission:", error)
+    }
+
+    return {
+      id: capsule.id,
+      title: capsule.title,
+      description: capsule.description,
+      content: capsule.status === PolaroidCapsuleStatus.UNLOCKED ? capsule.content : undefined,
+      type: capsule.type,
+      status: capsule.status,
+      userId: capsule.userId,
+      validationMethod: capsule.validationMethod,
+      confidenceThreshold: capsule.confidenceThreshold,
+      unlockedBySubmissionId: capsule.unlockedBySubmissionId,
+      unlockedAt: capsule.unlockedAt,
+      expiresAt: capsule.expiresAt,
+      metadata: capsule.metadata,
+      createdAt: capsule.createdAt,
+      updatedAt: capsule.updatedAt,
+      todaysTheme,
+      todaysSubmission,
+    }
+  }
+
+  private mapThemeToResponseDto(dailyTheme: any): DailyThemeResponseDto {
+    return {
+      id: dailyTheme.id,
+      date: dailyTheme.date,
+      theme: {
+        id: dailyTheme.theme.id,
+        name: dailyTheme.theme.name,
+        description: dailyTheme.theme.description,
+        category: dailyTheme.theme.category,
+        keywords: dailyTheme.theme.keywords,
+      },
+    }
+  }
+
+  private mapSubmissionToResponseDto(submission: any, dailyTheme: any): PhotoSubmissionResponseDto {
+    return {
+      id: submission.id,
+      photoUrl: submission.photoUrl,
+      thumbnailUrl: submission.thumbnailUrl,
+      caption: submission.caption,
+      status: submission.status,
+      confidenceScore: submission.confidenceScore,
+      rejectionReason: submission.rejectionReason,
+      submittedAt: submission.submittedAt,
+      reviewedAt: submission.reviewedAt,
+      dailyTheme: this.mapThemeToResponseDto(dailyTheme),
+    }
+  }
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/services/theme.service.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/services/theme.service.ts
@@ -1,0 +1,105 @@
+import { Injectable, NotFoundException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { PhotoTheme } from "../entities/photo-theme.entity"
+import { DailyTheme } from "../entities/daily-theme.entity"
+import type { CreatePhotoThemeDto } from "../dto/create-photo-theme.dto"
+
+@Injectable()
+export class ThemeService {
+  constructor(
+    @InjectRepository(PhotoTheme)
+    private readonly photoThemeRepository: Repository<PhotoTheme>,
+    @InjectRepository(DailyTheme)
+    private readonly dailyThemeRepository: Repository<DailyTheme>,
+  ) {}
+
+  async createTheme(createThemeDto: CreatePhotoThemeDto): Promise<PhotoTheme> {
+    const theme = this.photoThemeRepository.create(createThemeDto)
+    return await this.photoThemeRepository.save(theme)
+  }
+
+  async getThemeById(id: string): Promise<PhotoTheme> {
+    const theme = await this.photoThemeRepository.findOne({
+      where: { id },
+    })
+
+    if (!theme) {
+      throw new NotFoundException("Theme not found")
+    }
+
+    return theme
+  }
+
+  async getAllThemes(activeOnly = true): Promise<PhotoTheme[]> {
+    const query: any = {}
+    if (activeOnly) {
+      query.isActive = true
+    }
+
+    return await this.photoThemeRepository.find({
+      where: query,
+      order: { usageCount: "ASC" },
+    })
+  }
+
+  async getThemesByCategory(category: string, activeOnly = true): Promise<PhotoTheme[]> {
+    const query: any = { category }
+    if (activeOnly) {
+      query.isActive = true
+    }
+
+    return await this.photoThemeRepository.find({
+      where: query,
+      order: { usageCount: "ASC" },
+    })
+  }
+
+  async getDailyTheme(userId: string, date: Date = new Date()): Promise<DailyTheme> {
+    // Format date to remove time component
+    const formattedDate = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+
+    // Check if a theme is already assigned for this user and date
+    let dailyTheme = await this.dailyThemeRepository.findOne({
+      where: {
+        userId,
+        date: formattedDate,
+      },
+      relations: ["theme"],
+    })
+
+    // If no theme is assigned, assign a new one
+    if (!dailyTheme) {
+      dailyTheme = await this.assignNewDailyTheme(userId, formattedDate)
+    }
+
+    return dailyTheme
+  }
+
+  private async assignNewDailyTheme(userId: string, date: Date): Promise<DailyTheme> {
+    // Get all active themes
+    const themes = await this.getAllThemes(true)
+
+    if (themes.length === 0) {
+      throw new Error("No active themes available")
+    }
+
+    // Select a random theme, with preference for less used themes
+    const sortedThemes = themes.sort((a, b) => a.usageCount - b.usageCount)
+    const selectedTheme = sortedThemes[0]
+
+    // Increment usage count
+    selectedTheme.usageCount += 1
+    await this.photoThemeRepository.save(selectedTheme)
+
+    // Create daily theme
+    const dailyTheme = this.dailyThemeRepository.create({
+      userId,
+      themeId: selectedTheme.id,
+      date,
+      theme: selectedTheme,
+    })
+
+    return await this.dailyThemeRepository.save(dailyTheme)
+  }
+}

--- a/apps/capsulelabs-api/src/polaroid-capsule/tests/object-detection.service.spec.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/tests/object-detection.service.spec.ts
@@ -1,0 +1,144 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { ObjectDetectionService } from "../services/object-detection.service"
+import { ConfigService } from "@nestjs/config"
+import { HttpService } from "@nestjs/axios"
+import { of } from "rxjs"
+import { jest } from "@jest/globals"
+
+describe("ObjectDetectionService", () => {
+  let service: ObjectDetectionService
+  let configService: ConfigService
+  let httpService: HttpService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ObjectDetectionService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue?: any) => {
+              const config = {
+                VISION_API_KEY: "",
+                VISION_API_ENDPOINT: "",
+                USE_EXTERNAL_VISION_API: false,
+              }
+              return config[key] || defaultValue
+            }),
+          },
+        },
+        {
+          provide: HttpService,
+          useValue: {
+            post: jest.fn(),
+          },
+        },
+      ],
+    }).compile()
+
+    service = module.get<ObjectDetectionService>(ObjectDetectionService)
+    configService = module.get<ConfigService>(ConfigService)
+    httpService = module.get<HttpService>(HttpService)
+  })
+
+  it("should be defined", () => {
+    expect(service).toBeDefined()
+  })
+
+  describe("detectObjects", () => {
+    it("should return mock detection results when external API is disabled", async () => {
+      const imageUrl = "https://example.com/test-image.jpg"
+      const result = await service.detectObjects(imageUrl)
+
+      expect(result).toHaveProperty("labels")
+      expect(result).toHaveProperty("colors")
+      expect(result).toHaveProperty("confidence")
+      expect(result).toHaveProperty("rawResponse")
+      expect(Array.isArray(result.labels)).toBe(true)
+      expect(Array.isArray(result.colors)).toBe(true)
+      expect(typeof result.confidence).toBe("number")
+    })
+
+    it("should use external API when configured", async () => {
+      // Mock external API response
+      const mockResponse = {
+        data: {
+          responses: [
+            {
+              labelAnnotations: [
+                { description: "cat", score: 0.9 },
+                { description: "animal", score: 0.8 },
+              ],
+              imagePropertiesAnnotation: {
+                dominantColors: {
+                  colors: [{ color: { red: 255, green: 0, blue: 0 } }],
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      jest.spyOn(configService, "get").mockImplementation((key: string) => {
+        if (key === "USE_EXTERNAL_VISION_API") return true
+        if (key === "VISION_API_KEY") return "test-key"
+        if (key === "VISION_API_ENDPOINT") return "https://api.example.com"
+        return ""
+      })
+
+      jest.spyOn(httpService, "post").mockReturnValue(of(mockResponse))
+
+      const imageUrl = "https://example.com/cat.jpg"
+      const result = await service.detectObjects(imageUrl)
+
+      expect(result.labels).toContain("cat")
+      expect(result.labels).toContain("animal")
+      expect(result.confidence).toBeGreaterThan(0)
+    })
+  })
+
+  describe("matchImageToTheme", () => {
+    it("should match detected objects to theme keywords", () => {
+      const detectionResults = {
+        labels: ["cat", "animal", "pet"],
+        colors: ["brown", "white"],
+      }
+      const themeKeywords = ["animal", "pet", "furry"]
+
+      const result = service.matchImageToTheme(detectionResults, themeKeywords)
+
+      expect(result.isMatch).toBe(true)
+      expect(result.confidence).toBeGreaterThan(0)
+      expect(result.matchedKeywords).toContain("animal")
+      expect(result.matchedKeywords).toContain("pet")
+    })
+
+    it("should not match when no keywords overlap", () => {
+      const detectionResults = {
+        labels: ["car", "vehicle", "transportation"],
+        colors: ["red", "black"],
+      }
+      const themeKeywords = ["animal", "pet", "furry"]
+
+      const result = service.matchImageToTheme(detectionResults, themeKeywords)
+
+      expect(result.isMatch).toBe(false)
+      expect(result.confidence).toBe(0)
+      expect(result.matchedKeywords).toHaveLength(0)
+    })
+
+    it("should handle partial matches", () => {
+      const detectionResults = {
+        labels: ["yellow", "flower", "garden"],
+        colors: ["yellow", "green"],
+      }
+      const themeKeywords = ["yellow", "blue", "purple"]
+
+      const result = service.matchImageToTheme(detectionResults, themeKeywords)
+
+      expect(result.isMatch).toBe(true)
+      expect(result.confidence).toBeCloseTo(0.33, 1) // 1 out of 3 keywords matched
+      expect(result.matchedKeywords).toContain("yellow")
+    })
+  })
+})

--- a/apps/capsulelabs-api/src/polaroid-capsule/tests/theme.service.spec.ts
+++ b/apps/capsulelabs-api/src/polaroid-capsule/tests/theme.service.spec.ts
@@ -1,0 +1,119 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import { ThemeService } from "../services/theme.service"
+import { PhotoTheme } from "../entities/photo-theme.entity"
+import { DailyTheme } from "../entities/daily-theme.entity"
+import type { Repository } from "typeorm"
+
+describe("ThemeService", () => {
+  let service: ThemeService
+  let photoThemeRepository: Repository<PhotoTheme>
+  let dailyThemeRepository: Repository<DailyTheme>
+
+  const mockPhotoThemeRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    find: jest.fn(),
+  }
+
+  const mockDailyThemeRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ThemeService,
+        {
+          provide: getRepositoryToken(PhotoTheme),
+          useValue: mockPhotoThemeRepository,
+        },
+        {
+          provide: getRepositoryToken(DailyTheme),
+          useValue: mockDailyThemeRepository,
+        },
+      ],
+    }).compile()
+
+    service = module.get<ThemeService>(ThemeService)
+    photoThemeRepository = module.get<Repository<PhotoTheme>>(getRepositoryToken(PhotoTheme))
+    dailyThemeRepository = module.get<Repository<DailyTheme>>(getRepositoryToken(DailyTheme))
+  })
+
+  it("should be defined", () => {
+    expect(service).toBeDefined()
+  })
+
+  describe("createTheme", () => {
+    it("should create a new theme", async () => {
+      const createThemeDto = {
+        name: "Something Yellow",
+        description: "Take a photo of something yellow",
+        category: "color" as any,
+        keywords: ["yellow", "gold", "amber"],
+      }
+
+      const mockTheme = { id: "1", ...createThemeDto }
+      mockPhotoThemeRepository.create.mockReturnValue(mockTheme)
+      mockPhotoThemeRepository.save.mockResolvedValue(mockTheme)
+
+      const result = await service.createTheme(createThemeDto)
+
+      expect(mockPhotoThemeRepository.create).toHaveBeenCalledWith(createThemeDto)
+      expect(mockPhotoThemeRepository.save).toHaveBeenCalledWith(mockTheme)
+      expect(result).toEqual(mockTheme)
+    })
+  })
+
+  describe("getDailyTheme", () => {
+    it("should return existing daily theme if already assigned", async () => {
+      const userId = "user-1"
+      const date = new Date("2023-01-01")
+      const mockDailyTheme = {
+        id: "daily-1",
+        userId,
+        date,
+        theme: { id: "theme-1", name: "Something Yellow" },
+      }
+
+      mockDailyThemeRepository.findOne.mockResolvedValue(mockDailyTheme)
+
+      const result = await service.getDailyTheme(userId, date)
+
+      expect(result).toEqual(mockDailyTheme)
+      expect(mockDailyThemeRepository.findOne).toHaveBeenCalledWith({
+        where: { userId, date: new Date("2023-01-01") },
+        relations: ["theme"],
+      })
+    })
+
+    it("should assign new theme if none exists for the day", async () => {
+      const userId = "user-1"
+      const date = new Date("2023-01-01")
+      const mockThemes = [
+        { id: "theme-1", name: "Something Yellow", usageCount: 0 },
+        { id: "theme-2", name: "Something Blue", usageCount: 1 },
+      ]
+      const mockNewDailyTheme = {
+        id: "daily-1",
+        userId,
+        date,
+        theme: mockThemes[0],
+      }
+
+      mockDailyThemeRepository.findOne.mockResolvedValue(null)
+      mockPhotoThemeRepository.find.mockResolvedValue(mockThemes)
+      mockPhotoThemeRepository.save.mockResolvedValue({ ...mockThemes[0], usageCount: 1 })
+      mockDailyThemeRepository.create.mockReturnValue(mockNewDailyTheme)
+      mockDailyThemeRepository.save.mockResolvedValue(mockNewDailyTheme)
+
+      const result = await service.getDailyTheme(userId, date)
+
+      expect(result).toEqual(mockNewDailyTheme)
+      expect(mockPhotoThemeRepository.save).toHaveBeenCalledWith({ ...mockThemes[0], usageCount: 1 })
+    })
+  })
+})


### PR DESCRIPTION
This feature introduces a new experience where users must log a dream **before 9 AM** to unlock their dream capsule. The goal is to encourage early reflection and journaling.

### ✨ What’s Included:

* Dream logging prompt with text input
* Minimum word count validation for dream entries
* 9 AM local time cutoff enforcement
* Capsule unlock logic tied to valid dream submission

### 🛠️ Implementation Tasks:

* Built UI and backend endpoint for logging dreams
* Validated word count and timestamp on submission
* Linked valid logs to capsule unlocking mechanism

closes #54
closes #58
closes #59
