### PR TITLE
implemented the riddle feature and other capsules

### DIFF
--- a/apps/capsulelabs-api/src/riddle-capsule/controllers/riddle-capsule.controller.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/controllers/riddle-capsule.controller.ts
@@ -1,0 +1,54 @@
+import { Controller, Get, Post, Body, Param, Query, ParseUUIDPipe, ValidationPipe } from "@nestjs/common"
+import type { RiddleCapsuleService } from "../services/riddle-capsule.service"
+import type { CreateRiddleCapsuleDto } from "../dto/create-riddle-capsule.dto"
+import type { AnswerRiddleDto } from "../dto/answer-riddle.dto"
+import type { RiddleCapsuleResponseDto, RiddleAttemptResponseDto } from "../dto/riddle-capsule-response.dto"
+
+// Note: You'll need to implement your own authentication guard
+// import { AuthGuard } from '@nestjs/passport';
+// import { GetUser } from '../auth/get-user.decorator';
+
+@Controller("riddle-capsules")
+// @UseGuards(AuthGuard())
+export class RiddleCapsuleController {
+  constructor(private readonly riddleCapsuleService: RiddleCapsuleService) {}
+
+  @Post()
+  async createCapsule(
+    @Body(new ValidationPipe()) createCapsuleDto: CreateRiddleCapsuleDto,
+  ): Promise<RiddleCapsuleResponseDto> {
+    return await this.riddleCapsuleService.createCapsule(createCapsuleDto)
+  }
+
+  @Get()
+  async getUserCapsules(
+    @Query('userId') userId: string,
+  ): Promise<RiddleCapsuleResponseDto[]> {
+    return await this.riddleCapsuleService.getUserCapsules(userId)
+  }
+
+  @Get(":id")
+  async getCapsuleById(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('userId') userId: string,
+  ): Promise<RiddleCapsuleResponseDto> {
+    return await this.riddleCapsuleService.getCapsuleById(id, userId)
+  }
+
+  @Post(":id/answer")
+  async attemptRiddleAnswer(
+    @Param('id', ParseUUIDPipe) capsuleId: string,
+    @Query('userId') userId: string,
+    @Body(ValidationPipe) answerDto: AnswerRiddleDto,
+  ): Promise<RiddleAttemptResponseDto> {
+    return await this.riddleCapsuleService.attemptRiddleAnswer(capsuleId, userId, answerDto)
+  }
+
+  @Post(":id/hint")
+  async requestHint(
+    @Param('id', ParseUUIDPipe) capsuleId: string,
+    @Query('userId') userId: string,
+  ): Promise<{ hint: string }> {
+    return await this.riddleCapsuleService.requestHint(capsuleId, userId)
+  }
+}

--- a/apps/capsulelabs-api/src/riddle-capsule/controllers/riddle.controller.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/controllers/riddle.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Post, Body, Param, Query, ParseUUIDPipe, ValidationPipe } from "@nestjs/common"
+import type { RiddleService } from "../services/riddle.service"
+import type { CreateRiddleDto } from "../dto/create-riddle.dto"
+import type { Riddle } from "../entities/riddle.entity"
+import type { RiddleDifficulty } from "../entities/riddle-capsule.entity"
+
+// Note: This controller should be restricted to admin users
+// @UseGuards(AdminGuard)
+@Controller("riddles")
+export class RiddleController {
+  constructor(private readonly riddleService: RiddleService) {}
+
+  @Post()
+  async createRiddle(@Body(ValidationPipe) createRiddleDto: CreateRiddleDto): Promise<Riddle> {
+    return await this.riddleService.createRiddle(createRiddleDto)
+  }
+
+  @Get(":id")
+  async getRiddleById(@Param('id', ParseUUIDPipe) id: string): Promise<Riddle> {
+    return await this.riddleService.getRiddleById(id)
+  }
+
+  @Get("random")
+  async getRandomRiddle(
+    @Query('difficulty') difficulty?: RiddleDifficulty,
+  ): Promise<Riddle> {
+    return await this.riddleService.getRandomRiddle(difficulty)
+  }
+}

--- a/apps/capsulelabs-api/src/riddle-capsule/dto/answer-riddle.dto.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/dto/answer-riddle.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, IsOptional, IsObject } from "class-validator"
+
+export class AnswerRiddleDto {
+  @IsString()
+  answer: string
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/riddle-capsule/dto/create-riddle-capsule.dto.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/dto/create-riddle-capsule.dto.ts
@@ -1,0 +1,40 @@
+import { IsString, IsOptional, IsEnum, IsDateString, IsObject, IsBoolean, IsUUID } from "class-validator"
+import { RiddleCapsuleType, RiddleDifficulty } from "../entities/riddle-capsule.entity"
+
+export class CreateRiddleCapsuleDto {
+  @IsString()
+  title: string
+
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @IsObject()
+  content: Record<string, any>
+
+  @IsEnum(RiddleCapsuleType)
+  type: RiddleCapsuleType
+
+  @IsString()
+  userId: string
+
+  @IsOptional()
+  @IsEnum(RiddleDifficulty)
+  preferredDifficulty?: RiddleDifficulty
+
+  @IsOptional()
+  @IsBoolean()
+  useExternalApi?: boolean
+
+  @IsOptional()
+  @IsUUID()
+  specificRiddleId?: string
+
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/riddle-capsule/dto/create-riddle.dto.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/dto/create-riddle.dto.ts
@@ -1,0 +1,29 @@
+import { IsString, IsOptional, IsEnum, IsObject, IsBoolean } from "class-validator"
+import { RiddleCategory } from "../entities/riddle.entity"
+import { RiddleDifficulty } from "../entities/riddle-capsule.entity"
+
+export class CreateRiddleDto {
+  @IsString()
+  question: string
+
+  @IsString()
+  answer: string
+
+  @IsOptional()
+  @IsString()
+  hint?: string
+
+  @IsEnum(RiddleCategory)
+  category: RiddleCategory
+
+  @IsEnum(RiddleDifficulty)
+  difficulty: RiddleDifficulty
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean
+}

--- a/apps/capsulelabs-api/src/riddle-capsule/dto/riddle-capsule-response.dto.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/dto/riddle-capsule-response.dto.ts
@@ -1,0 +1,37 @@
+import type { RiddleCapsuleStatus, RiddleCapsuleType, RiddleDifficulty } from "../entities/riddle-capsule.entity"
+import type { RiddleCategory } from "../entities/riddle.entity"
+
+export class RiddleResponseDto {
+  id: string
+  question: string
+  hint?: string
+  category: RiddleCategory
+  difficulty: RiddleDifficulty
+}
+
+export class RiddleCapsuleResponseDto {
+  id: string
+  title: string
+  description?: string
+  content?: Record<string, any>
+  type: RiddleCapsuleType
+  status: RiddleCapsuleStatus
+  userId: string
+  preferredDifficulty: RiddleDifficulty
+  unlockedAt?: Date
+  expiresAt?: Date
+  metadata?: Record<string, any>
+  createdAt: Date
+  updatedAt: Date
+  currentRiddle?: RiddleResponseDto
+  nextAttemptAllowedAt?: Date
+}
+
+export class RiddleAttemptResponseDto {
+  success: boolean
+  message: string
+  isCorrect: boolean
+  similarityScore?: number
+  capsule?: RiddleCapsuleResponseDto
+  nextAttemptAllowedAt?: Date
+}

--- a/apps/capsulelabs-api/src/riddle-capsule/entities/riddle-attempt.entity.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/entities/riddle-attempt.entity.ts
@@ -1,0 +1,45 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, JoinColumn } from "typeorm"
+import { RiddleCapsule } from "./riddle-capsule.entity"
+
+@Entity("riddle_attempts")
+export class RiddleAttempt {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "uuid" })
+  capsuleId: string
+
+  @Column({ type: "uuid" })
+  riddleId: string
+
+  @Column({ type: "text" })
+  submittedAnswer: string
+
+  @Column({ type: "boolean" })
+  isCorrect: boolean
+
+  @Column({ type: "float", nullable: true })
+  similarityScore: number
+
+  @CreateDateColumn()
+  attemptedAt: Date
+
+  @Column({ type: "timestamp" })
+  nextAttemptAllowedAt: Date
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @ManyToOne(
+    () => RiddleCapsule,
+    (capsule) => capsule.interactionLogs,
+    {
+      onDelete: "CASCADE",
+    },
+  )
+  @JoinColumn({ name: "capsuleId" })
+  capsule: RiddleCapsule
+}

--- a/apps/capsulelabs-api/src/riddle-capsule/entities/riddle-capsule-interaction-log.entity.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/entities/riddle-capsule-interaction-log.entity.ts
@@ -1,0 +1,52 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, JoinColumn } from "typeorm"
+import { RiddleCapsule } from "./riddle-capsule.entity"
+
+export enum RiddleInteractionType {
+  CREATED = "created",
+  VIEWED = "viewed",
+  RIDDLE_ASSIGNED = "riddle_assigned",
+  RIDDLE_ATTEMPTED = "riddle_attempted",
+  UNLOCKED = "unlocked",
+  EXPIRED = "expired",
+  HINT_REQUESTED = "hint_requested",
+}
+
+@Entity("riddle_capsule_interaction_logs")
+export class RiddleCapsuleInteractionLog {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "uuid" })
+  capsuleId: string
+
+  @Column({
+    type: "enum",
+    enum: RiddleInteractionType,
+  })
+  type: RiddleInteractionType
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  userAgent: string
+
+  @Column({ type: "inet", nullable: true })
+  ipAddress: string
+
+  @CreateDateColumn()
+  timestamp: Date
+
+  @ManyToOne(
+    () => RiddleCapsule,
+    (capsule) => capsule.interactionLogs,
+    {
+      onDelete: "CASCADE",
+    },
+  )
+  @JoinColumn({ name: "capsuleId" })
+  capsule: RiddleCapsule
+}

--- a/apps/capsulelabs-api/src/riddle-capsule/entities/riddle-capsule.entity.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/entities/riddle-capsule.entity.ts
@@ -1,0 +1,103 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  OneToMany,
+  ManyToOne,
+  JoinColumn,
+} from "typeorm"
+import { RiddleCapsuleInteractionLog } from "./riddle-capsule-interaction-log.entity"
+import { Riddle } from "./riddle.entity"
+
+export enum RiddleCapsuleStatus {
+  LOCKED = "locked",
+  UNLOCKED = "unlocked",
+  EXPIRED = "expired",
+}
+
+export enum RiddleCapsuleType {
+  TEXT = "text",
+  IMAGE = "image",
+  VIDEO = "video",
+  AUDIO = "audio",
+  MIXED = "mixed",
+}
+
+export enum RiddleDifficulty {
+  EASY = "easy",
+  MEDIUM = "medium",
+  HARD = "hard",
+  EXPERT = "expert",
+}
+
+@Entity("riddle_capsules")
+export class RiddleCapsule {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "varchar", length: 255 })
+  title: string
+
+  @Column({ type: "text", nullable: true })
+  description: string
+
+  @Column({ type: "jsonb" })
+  content: Record<string, any>
+
+  @Column({
+    type: "enum",
+    enum: RiddleCapsuleType,
+    default: RiddleCapsuleType.TEXT,
+  })
+  type: RiddleCapsuleType
+
+  @Column({
+    type: "enum",
+    enum: RiddleCapsuleStatus,
+    default: RiddleCapsuleStatus.LOCKED,
+  })
+  status: RiddleCapsuleStatus
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "uuid", nullable: true })
+  riddleId: string
+
+  @Column({
+    type: "enum",
+    enum: RiddleDifficulty,
+    default: RiddleDifficulty.MEDIUM,
+  })
+  preferredDifficulty: RiddleDifficulty
+
+  @Column({ type: "boolean", default: false })
+  useExternalApi: boolean
+
+  @Column({ type: "timestamp", nullable: true })
+  unlockedAt: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  expiresAt: Date
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+
+  @ManyToOne(() => Riddle, { nullable: true })
+  @JoinColumn({ name: "riddleId" })
+  riddle: Riddle
+
+  @OneToMany(
+    () => RiddleCapsuleInteractionLog,
+    (log) => log.capsule,
+  )
+  interactionLogs: RiddleCapsuleInteractionLog[]
+}

--- a/apps/capsulelabs-api/src/riddle-capsule/entities/riddle.entity.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/entities/riddle.entity.ts
@@ -1,0 +1,55 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from "typeorm"
+import { RiddleDifficulty } from "./riddle-capsule.entity"
+
+export enum RiddleCategory {
+  WORDPLAY = "wordplay",
+  LOGIC = "logic",
+  MATH = "math",
+  LATERAL = "lateral",
+  MYSTERY = "mystery",
+  RIDDLE = "riddle",
+}
+
+@Entity("riddles")
+export class Riddle {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "text" })
+  question: string
+
+  @Column({ type: "text" })
+  answer: string
+
+  @Column({ type: "text", nullable: true })
+  hint: string
+
+  @Column({
+    type: "enum",
+    enum: RiddleCategory,
+    default: RiddleCategory.RIDDLE,
+  })
+  category: RiddleCategory
+
+  @Column({
+    type: "enum",
+    enum: RiddleDifficulty,
+    default: RiddleDifficulty.MEDIUM,
+  })
+  difficulty: RiddleDifficulty
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @Column({ type: "boolean", default: true })
+  isActive: boolean
+
+  @Column({ type: "int", default: 0 })
+  usageCount: number
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+}

--- a/apps/capsulelabs-api/src/riddle-capsule/riddle-capsule.module.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/riddle-capsule.module.ts
@@ -1,0 +1,20 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { HttpModule } from "@nestjs/axios"
+import { RiddleCapsuleController } from "./controllers/riddle-capsule.controller"
+import { RiddleController } from "./controllers/riddle.controller"
+import { RiddleCapsuleService } from "./services/riddle-capsule.service"
+import { RiddleService } from "./services/riddle.service"
+import { RiddleValidationService } from "./services/riddle-validation.service"
+import { RiddleCapsule } from "./entities/riddle-capsule.entity"
+import { Riddle } from "./entities/riddle.entity"
+import { RiddleAttempt } from "./entities/riddle-attempt.entity"
+import { RiddleCapsuleInteractionLog } from "./entities/riddle-capsule-interaction-log.entity"
+
+@Module({
+  imports: [TypeOrmModule.forFeature([RiddleCapsule, Riddle, RiddleAttempt, RiddleCapsuleInteractionLog]), HttpModule],
+  controllers: [RiddleCapsuleController, RiddleController],
+  providers: [RiddleCapsuleService, RiddleService, RiddleValidationService],
+  exports: [RiddleCapsuleService, RiddleService],
+})
+export class RiddleCapsuleModule {}

--- a/apps/capsulelabs-api/src/riddle-capsule/services/riddle-capsule.service.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/services/riddle-capsule.service.ts
@@ -1,0 +1,310 @@
+import { Injectable, NotFoundException, BadRequestException, ForbiddenException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { RiddleCapsule, RiddleCapsuleStatus } from "../entities/riddle-capsule.entity"
+import { RiddleCapsuleInteractionLog, RiddleInteractionType } from "../entities/riddle-capsule-interaction-log.entity"
+import { RiddleAttempt } from "../entities/riddle-attempt.entity"
+import type { CreateRiddleCapsuleDto } from "../dto/create-riddle-capsule.dto"
+import type { AnswerRiddleDto } from "../dto/answer-riddle.dto"
+import type { RiddleCapsuleResponseDto, RiddleAttemptResponseDto } from "../dto/riddle-capsule-response.dto"
+import type { RiddleService } from "./riddle.service"
+import type { RiddleValidationService } from "./riddle-validation.service"
+
+@Injectable()
+export class RiddleCapsuleService {
+  constructor(
+    @InjectRepository(RiddleCapsule) private riddleCapsuleRepository: Repository<RiddleCapsule>,
+    @InjectRepository(RiddleCapsuleInteractionLog)
+    private interactionLogRepository: Repository<RiddleCapsuleInteractionLog>,
+    @InjectRepository(RiddleAttempt) private riddleAttemptRepository: Repository<RiddleAttempt>,
+    private riddleService: RiddleService,
+    private riddleValidationService: RiddleValidationService,
+  ) {}
+
+  async createCapsule(createCapsuleDto: CreateRiddleCapsuleDto): Promise<RiddleCapsuleResponseDto> {
+    let riddleId: string | null = null
+
+    // If a specific riddle ID is provided, verify it exists
+    if (createCapsuleDto.specificRiddleId) {
+      const riddle = await this.riddleService.getRiddleById(createCapsuleDto.specificRiddleId)
+      riddleId = riddle.id
+    }
+    // Otherwise, if not using external API, assign a random riddle based on preferred difficulty
+    else if (!createCapsuleDto.useExternalApi) {
+      const riddle = await this.riddleService.getRandomRiddle(createCapsuleDto.preferredDifficulty)
+      riddleId = riddle.id
+    }
+
+    const capsule = this.riddleCapsuleRepository.create({
+      ...createCapsuleDto,
+      riddleId,
+      expiresAt: createCapsuleDto.expiresAt ? new Date(createCapsuleDto.expiresAt) : null,
+    })
+
+    const savedCapsule = await this.riddleCapsuleRepository.save(capsule)
+
+    // Log the creation
+    await this.logInteraction(savedCapsule.userId, savedCapsule.id, RiddleInteractionType.CREATED, {
+      capsuleType: savedCapsule.type,
+      useExternalApi: savedCapsule.useExternalApi,
+      riddleId: savedCapsule.riddleId,
+    })
+
+    // If a riddle was assigned, log it
+    if (riddleId) {
+      await this.logInteraction(savedCapsule.userId, savedCapsule.id, RiddleInteractionType.RIDDLE_ASSIGNED, {
+        riddleId,
+      })
+    }
+
+    return this.mapToResponseDto(savedCapsule)
+  }
+
+  async getCapsuleById(id: string, userId: string): Promise<RiddleCapsuleResponseDto> {
+    const capsule = await this.riddleCapsuleRepository.findOne({
+      where: { id, userId },
+      relations: ["riddle"],
+    })
+
+    if (!capsule) {
+      throw new NotFoundException("Riddle capsule not found")
+    }
+
+    // Log the view
+    await this.logInteraction(userId, id, RiddleInteractionType.VIEWED)
+
+    // If the capsule doesn't have a riddle assigned yet and it's locked, assign one
+    if (!capsule.riddleId && capsule.status === RiddleCapsuleStatus.LOCKED) {
+      await this.assignRiddleToCapsule(capsule)
+    }
+
+    // Get the latest attempt to check rate limiting
+    const latestAttempt = await this.getLatestAttempt(userId, id)
+
+    return this.mapToResponseDto(capsule, latestAttempt)
+  }
+
+  async getUserCapsules(userId: string): Promise<RiddleCapsuleResponseDto[]> {
+    const capsules = await this.riddleCapsuleRepository.find({
+      where: { userId },
+      order: { createdAt: "DESC" },
+      relations: ["riddle"],
+    })
+
+    const results: RiddleCapsuleResponseDto[] = []
+
+    for (const capsule of capsules) {
+      const latestAttempt = await this.getLatestAttempt(userId, capsule.id)
+      results.push(this.mapToResponseDto(capsule, latestAttempt))
+    }
+
+    return results
+  }
+
+  async attemptRiddleAnswer(
+    capsuleId: string,
+    userId: string,
+    answerDto: AnswerRiddleDto,
+  ): Promise<RiddleAttemptResponseDto> {
+    const capsule = await this.riddleCapsuleRepository.findOne({
+      where: { id: capsuleId, userId },
+      relations: ["riddle"],
+    })
+
+    if (!capsule) {
+      throw new NotFoundException("Riddle capsule not found")
+    }
+
+    if (capsule.status !== RiddleCapsuleStatus.LOCKED) {
+      throw new BadRequestException("Capsule is not locked")
+    }
+
+    // Check if the user has a riddle assigned
+    if (!capsule.riddleId && !capsule.useExternalApi) {
+      await this.assignRiddleToCapsule(capsule)
+    }
+
+    // Check rate limiting
+    await this.checkRateLimiting(userId, capsuleId)
+
+    // Get the riddle (either from DB or external API)
+    const riddle = capsule.useExternalApi
+      ? await this.riddleService.getRiddlesFromExternalApi(capsule.preferredDifficulty)
+      : await this.riddleService.getRiddleById(capsule.riddleId)
+
+    // Validate the answer
+    const { isCorrect, similarityScore } = this.riddleValidationService.validateAnswer(riddle, answerDto.answer)
+
+    // Calculate next attempt time (12 hours from now)
+    const nextAttemptAllowedAt = new Date()
+    nextAttemptAllowedAt.setHours(nextAttemptAllowedAt.getHours() + 12)
+
+    // Record the attempt
+    const attempt = this.riddleAttemptRepository.create({
+      userId,
+      capsuleId,
+      riddleId: riddle.id,
+      submittedAnswer: answerDto.answer,
+      isCorrect,
+      similarityScore,
+      nextAttemptAllowedAt,
+      metadata: answerDto.metadata,
+    })
+
+    await this.riddleAttemptRepository.save(attempt)
+
+    // Log the attempt
+    await this.logInteraction(userId, capsuleId, RiddleInteractionType.RIDDLE_ATTEMPTED, {
+      riddleId: riddle.id,
+      isCorrect,
+      similarityScore,
+    })
+
+    if (isCorrect) {
+      // Unlock the capsule
+      capsule.status = RiddleCapsuleStatus.UNLOCKED
+      capsule.unlockedAt = new Date()
+      await this.riddleCapsuleRepository.save(capsule)
+
+      // Log successful unlock
+      await this.logInteraction(userId, capsuleId, RiddleInteractionType.UNLOCKED)
+
+      return {
+        success: true,
+        message: "Correct answer! Capsule unlocked successfully.",
+        isCorrect: true,
+        similarityScore,
+        capsule: this.mapToResponseDto(capsule),
+      }
+    } else {
+      let message = "Incorrect answer. Try again in 12 hours."
+
+      // If the answer was close, give a hint
+      if (similarityScore > 0.7) {
+        message = "Close, but not quite right. Try again in 12 hours."
+      }
+
+      return {
+        success: false,
+        message,
+        isCorrect: false,
+        similarityScore,
+        nextAttemptAllowedAt: attempt.nextAttemptAllowedAt,
+      }
+    }
+  }
+
+  async requestHint(capsuleId: string, userId: string): Promise<{ hint: string }> {
+    const capsule = await this.riddleCapsuleRepository.findOne({
+      where: { id: capsuleId, userId },
+      relations: ["riddle"],
+    })
+
+    if (!capsule) {
+      throw new NotFoundException("Riddle capsule not found")
+    }
+
+    if (capsule.status !== RiddleCapsuleStatus.LOCKED) {
+      throw new BadRequestException("Capsule is not locked")
+    }
+
+    // Get the riddle (either from DB or external API)
+    const riddle = capsule.useExternalApi
+      ? await this.riddleService.getRiddlesFromExternalApi(capsule.preferredDifficulty)
+      : await this.riddleService.getRiddleById(capsule.riddleId)
+
+    if (!riddle.hint) {
+      throw new BadRequestException("No hint available for this riddle")
+    }
+
+    // Log the hint request
+    await this.logInteraction(userId, capsuleId, RiddleInteractionType.HINT_REQUESTED)
+
+    return { hint: riddle.hint }
+  }
+
+  private async assignRiddleToCapsule(capsule: RiddleCapsule): Promise<void> {
+    // Get a random riddle based on preferred difficulty
+    const riddle = await this.riddleService.getRandomRiddle(capsule.preferredDifficulty)
+
+    // Assign the riddle to the capsule
+    capsule.riddleId = riddle.id
+    capsule.riddle = riddle
+    await this.riddleCapsuleRepository.save(capsule)
+
+    // Log the riddle assignment
+    await this.logInteraction(capsule.userId, capsule.id, RiddleInteractionType.RIDDLE_ASSIGNED, {
+      riddleId: riddle.id,
+    })
+  }
+
+  private async checkRateLimiting(userId: string, capsuleId: string): Promise<void> {
+    const latestAttempt = await this.getLatestAttempt(userId, capsuleId)
+
+    if (latestAttempt && new Date() < latestAttempt.nextAttemptAllowedAt) {
+      const timeRemaining = Math.ceil((latestAttempt.nextAttemptAllowedAt.getTime() - Date.now()) / (1000 * 60 * 60))
+      throw new ForbiddenException(
+        `Rate limit exceeded. You can attempt again in ${timeRemaining} hour${timeRemaining !== 1 ? "s" : ""}.`,
+      )
+    }
+  }
+
+  private async getLatestAttempt(userId: string, capsuleId: string): Promise<RiddleAttempt | null> {
+    return await this.riddleAttemptRepository.findOne({
+      where: { userId, capsuleId },
+      order: { attemptedAt: "DESC" },
+    })
+  }
+
+  private async logInteraction(
+    userId: string,
+    capsuleId: string,
+    type: RiddleInteractionType,
+    metadata?: Record<string, any>,
+  ): Promise<void> {
+    const log = this.interactionLogRepository.create({
+      userId,
+      capsuleId,
+      type,
+      metadata,
+    })
+
+    await this.interactionLogRepository.save(log)
+  }
+
+  private mapToResponseDto(capsule: RiddleCapsule, latestAttempt?: RiddleAttempt | null): RiddleCapsuleResponseDto {
+    const response: RiddleCapsuleResponseDto = {
+      id: capsule.id,
+      title: capsule.title,
+      description: capsule.description,
+      content: capsule.status === RiddleCapsuleStatus.UNLOCKED ? capsule.content : undefined,
+      type: capsule.type,
+      status: capsule.status,
+      userId: capsule.userId,
+      preferredDifficulty: capsule.preferredDifficulty,
+      unlockedAt: capsule.unlockedAt,
+      expiresAt: capsule.expiresAt,
+      metadata: capsule.metadata,
+      createdAt: capsule.createdAt,
+      updatedAt: capsule.updatedAt,
+    }
+
+    // Add current riddle if capsule is locked
+    if (capsule.status === RiddleCapsuleStatus.LOCKED && capsule.riddle) {
+      response.currentRiddle = {
+        id: capsule.riddle.id,
+        question: capsule.riddle.question,
+        hint: undefined, // Don't include hint by default, must be requested
+        category: capsule.riddle.category,
+        difficulty: capsule.riddle.difficulty,
+      }
+    }
+
+    // Add next attempt time if rate limited
+    if (latestAttempt && new Date() < latestAttempt.nextAttemptAllowedAt) {
+      response.nextAttemptAllowedAt = latestAttempt.nextAttemptAllowedAt
+    }
+
+    return response
+  }
+}

--- a/apps/capsulelabs-api/src/riddle-capsule/services/riddle-validation.service.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/services/riddle-validation.service.ts
@@ -1,0 +1,99 @@
+import { Injectable } from "@nestjs/common"
+import type { Riddle } from "../entities/riddle.entity"
+
+@Injectable()
+export class RiddleValidationService {
+  /**
+   * Validate a user's answer against the correct riddle answer
+   * Returns a similarity score between 0 and 1
+   */
+  validateAnswer(riddle: Riddle, userAnswer: string): { isCorrect: boolean; similarityScore: number } {
+    if (!userAnswer || !riddle.answer) {
+      return { isCorrect: false, similarityScore: 0 }
+    }
+
+    // Normalize both answers for comparison
+    const normalizedUserAnswer = this.normalizeAnswer(userAnswer)
+    const normalizedCorrectAnswer = this.normalizeAnswer(riddle.answer)
+
+    // Check for exact match after normalization
+    if (normalizedUserAnswer === normalizedCorrectAnswer) {
+      return { isCorrect: true, similarityScore: 1 }
+    }
+
+    // Check for alternative answers if provided in metadata
+    const alternativeAnswers = riddle.metadata?.alternativeAnswers || []
+    for (const altAnswer of alternativeAnswers) {
+      if (this.normalizeAnswer(altAnswer) === normalizedUserAnswer) {
+        return { isCorrect: true, similarityScore: 1 }
+      }
+    }
+
+    // Calculate similarity score for close matches
+    const similarityScore = this.calculateSimilarity(normalizedCorrectAnswer, normalizedUserAnswer)
+    const isCorrect = similarityScore >= 0.85 // 85% similarity threshold for correct answers
+
+    return { isCorrect, similarityScore }
+  }
+
+  /**
+   * Normalize an answer string for comparison
+   * - Convert to lowercase
+   * - Remove punctuation and special characters
+   * - Remove extra whitespace
+   */
+  private normalizeAnswer(answer: string): string {
+    return answer
+      .toLowerCase()
+      .replace(/[^\w\s]/g, "") // Remove punctuation and special characters
+      .replace(/\s+/g, " ") // Replace multiple spaces with a single space
+      .trim()
+  }
+
+  /**
+   * Calculate similarity between two strings using Levenshtein distance
+   * Returns a score between 0 (completely different) and 1 (identical)
+   */
+  private calculateSimilarity(str1: string, str2: string): number {
+    if (str1 === str2) return 1
+    if (str1.length === 0) return 0
+    if (str2.length === 0) return 0
+
+    const levenshteinDistance = this.levenshteinDistance(str1, str2)
+    return 1 - levenshteinDistance / Math.max(str1.length, str2.length)
+  }
+
+  /**
+   * Calculate Levenshtein distance between two strings
+   * This measures the minimum number of single-character edits required to change one string into the other
+   */
+  private levenshteinDistance(str1: string, str2: string): number {
+    const matrix: number[][] = []
+
+    // Initialize matrix
+    for (let i = 0; i <= str2.length; i++) {
+      matrix[i] = [i]
+    }
+
+    for (let j = 0; j <= str1.length; j++) {
+      matrix[0][j] = j
+    }
+
+    // Fill matrix
+    for (let i = 1; i <= str2.length; i++) {
+      for (let j = 1; j <= str1.length; j++) {
+        if (str2.charAt(i - 1) === str1.charAt(j - 1)) {
+          matrix[i][j] = matrix[i - 1][j - 1]
+        } else {
+          matrix[i][j] = Math.min(
+            matrix[i - 1][j - 1] + 1, // substitution
+            matrix[i][j - 1] + 1, // insertion
+            matrix[i - 1][j] + 1, // deletion
+          )
+        }
+      }
+    }
+
+    return matrix[str2.length][str1.length]
+  }
+}

--- a/apps/capsulelabs-api/src/riddle-capsule/services/riddle.service.ts
+++ b/apps/capsulelabs-api/src/riddle-capsule/services/riddle.service.ts
@@ -1,0 +1,125 @@
+import { Injectable, NotFoundException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { Riddle, RiddleCategory } from "../entities/riddle.entity"
+import { RiddleDifficulty } from "../entities/riddle-capsule.entity"
+import type { CreateRiddleDto } from "../dto/create-riddle.dto"
+import type { HttpService } from "@nestjs/axios"
+import type { ConfigService } from "@nestjs/config"
+import { firstValueFrom } from "rxjs"
+
+@Injectable()
+export class RiddleService {
+  private readonly externalApiUrl: string;
+
+  constructor(
+    private httpService: HttpService,
+    private configService: ConfigService,
+    @InjectRepository(Riddle)
+    private riddleRepository: Repository<Riddle>,
+  ) {
+    this.externalApiUrl = this.configService.get<string>("RIDDLE_API_URL", "https://api.example.com/riddles")
+  }
+
+  async createRiddle(createRiddleDto: CreateRiddleDto): Promise<Riddle> {
+    const riddle = this.riddleRepository.create(createRiddleDto)
+    return await this.riddleRepository.save(riddle)
+  }
+
+  async getRiddleById(id: string): Promise<Riddle> {
+    const riddle = await this.riddleRepository.findOne({
+      where: { id },
+    })
+
+    if (!riddle) {
+      throw new NotFoundException("Riddle not found")
+    }
+
+    return riddle
+  }
+
+  async getRandomRiddle(difficulty?: RiddleDifficulty, category?: RiddleCategory): Promise<Riddle> {
+    const queryBuilder = this.riddleRepository.createQueryBuilder("riddle").where("riddle.isActive = :isActive", {
+      isActive: true,
+    })
+
+    if (difficulty) {
+      queryBuilder.andWhere("riddle.difficulty = :difficulty", { difficulty })
+    }
+
+    if (category) {
+      queryBuilder.andWhere("riddle.category = :category", { category })
+    }
+
+    // Order by usage count (ascending) and then randomly
+    queryBuilder.orderBy("riddle.usageCount", "ASC").addOrderBy("RANDOM()")
+
+    // Get the first result
+    const riddle = await queryBuilder.getOne()
+
+    if (!riddle) {
+      throw new NotFoundException("No suitable riddles found")
+    }
+
+    // Increment usage count
+    await this.riddleRepository.update(riddle.id, {
+      usageCount: () => "usage_count + 1",
+    })
+
+    return riddle
+  }
+
+  async getRiddlesFromExternalApi(difficulty?: RiddleDifficulty): Promise<Riddle> {
+    try {
+      let apiUrl = this.externalApiUrl
+      if (difficulty) {
+        apiUrl += `?difficulty=${difficulty.toLowerCase()}`
+      }
+
+      const response = await firstValueFrom(this.httpService.get(apiUrl))
+      const riddleData = response.data
+
+      // Map external API response to our Riddle entity structure
+      // This assumes the API returns data in a compatible format
+      // You may need to adjust this mapping based on the actual API response
+      const riddle = new Riddle()
+      riddle.id = riddleData.id || `external-${Date.now()}`
+      riddle.question = riddleData.question
+      riddle.answer = riddleData.answer
+      riddle.hint = riddleData.hint
+      riddle.difficulty = this.mapExternalDifficultyToInternal(riddleData.difficulty)
+      riddle.category = this.mapExternalCategoryToInternal(riddleData.category)
+      riddle.metadata = { source: "external_api", originalData: riddleData }
+
+      return riddle
+    } catch (error) {
+      // If external API fails, fall back to internal database
+      console.error("External riddle API error:", error.message)
+      return this.getRandomRiddle(difficulty)
+    }
+  }
+
+  private mapExternalDifficultyToInternal(externalDifficulty: string): RiddleDifficulty {
+    const difficultyMap = {
+      easy: RiddleDifficulty.EASY,
+      medium: RiddleDifficulty.MEDIUM,
+      hard: RiddleDifficulty.HARD,
+      expert: RiddleDifficulty.EXPERT,
+    }
+
+    return difficultyMap[externalDifficulty?.toLowerCase()] || RiddleDifficulty.MEDIUM
+  }
+
+  private mapExternalCategoryToInternal(externalCategory: string): RiddleCategory {
+    const categoryMap = {
+      wordplay: RiddleCategory.WORDPLAY,
+      logic: RiddleCategory.LOGIC,
+      math: RiddleCategory.MATH,
+      lateral: RiddleCategory.LATERAL,
+      mystery: RiddleCategory.MYSTERY,
+      riddle: RiddleCategory.RIDDLE,
+    }
+
+    return categoryMap[externalCategory?.toLowerCase()] || RiddleCategory.RIDDLE
+  }
+}

--- a/apps/capsulelabs-api/src/shadow-capsule/controllers/shadow-capsule.controller.ts
+++ b/apps/capsulelabs-api/src/shadow-capsule/controllers/shadow-capsule.controller.ts
@@ -1,0 +1,54 @@
+import { Controller, Get, Post, Body, Param, Query, ParseUUIDPipe, ValidationPipe, Patch } from "@nestjs/common"
+import type { ShadowCapsuleService } from "../services/shadow-capsule.service"
+import type { CreateShadowCapsuleDto } from "../dto/create-shadow-capsule.dto"
+import type { UpdateLocationDto } from "../dto/update-location.dto"
+import type { ShadowCapsuleResponseDto, UnlockAttemptResponseDto } from "../dto/shadow-capsule-response.dto"
+
+// Note: You'll need to implement your own authentication guard
+// import { AuthGuard } from '@nestjs/passport';
+// import { GetUser } from '../auth/get-user.decorator';
+
+@Controller("shadow-capsules")
+// @UseGuards(AuthGuard())
+export class ShadowCapsuleController {
+  constructor(private readonly shadowCapsuleService: ShadowCapsuleService) {}
+
+  @Post()
+  async createCapsule(
+    @Body() createCapsuleDto: CreateShadowCapsuleDto,
+  ): Promise<ShadowCapsuleResponseDto> {
+    return await this.shadowCapsuleService.createCapsule(createCapsuleDto)
+  }
+
+  @Get()
+  async getUserCapsules(
+    @Query('userId') userId: string,
+  ): Promise<ShadowCapsuleResponseDto[]> {
+    return await this.shadowCapsuleService.getUserCapsules(userId)
+  }
+
+  @Get(":id")
+  async getCapsuleById(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('userId') userId: string,
+  ): Promise<ShadowCapsuleResponseDto> {
+    return await this.shadowCapsuleService.getCapsuleById(id, userId)
+  }
+
+  @Post(":id/unlock")
+  async attemptUnlock(
+    @Param('id', ParseUUIDPipe) capsuleId: string,
+    @Query('userId') userId: string,
+  ): Promise<UnlockAttemptResponseDto> {
+    return await this.shadowCapsuleService.attemptUnlock(capsuleId, userId)
+  }
+
+  @Patch(":id/location")
+  async updateLocation(
+    @Param('id', ParseUUIDPipe) capsuleId: string,
+    @Query('userId') userId: string,
+    @Body(ValidationPipe) updateLocationDto: UpdateLocationDto,
+  ): Promise<ShadowCapsuleResponseDto> {
+    return await this.shadowCapsuleService.updateLocation(capsuleId, userId, updateLocationDto)
+  }
+}

--- a/apps/capsulelabs-api/src/shadow-capsule/cron/twilight-update.cron.ts
+++ b/apps/capsulelabs-api/src/shadow-capsule/cron/twilight-update.cron.ts
@@ -1,0 +1,55 @@
+import { Injectable } from "@nestjs/common"
+import { Cron, CronExpression } from "@nestjs/schedule"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { ShadowCapsule } from "../entities/shadow-capsule.entity"
+import type { TwilightCalculationService } from "../services/twilight-calculation.service"
+import { Logger } from "@nestjs/common"
+
+@Injectable()
+export class TwilightUpdateCron {
+  private readonly logger = new Logger(TwilightUpdateCron.name);
+
+  constructor(
+    private twilightCalculationService: TwilightCalculationService,
+    @InjectRepository(ShadowCapsule)
+    private shadowCapsuleRepository: Repository<ShadowCapsule>,
+  ) {}
+
+  /**
+   * Update twilight times for all capsules twice daily
+   * This ensures that capsules have accurate twilight times
+   */
+  @Cron(CronExpression.EVERY_12_HOURS)
+  async updateAllCapsuleTwilightTimes() {
+    this.logger.log("Updating twilight times for all shadow capsules")
+
+    try {
+      // Get all locked capsules
+      const capsules = await this.shadowCapsuleRepository.find({
+        where: { status: "locked" },
+      })
+
+      this.logger.log(`Found ${capsules.length} locked shadow capsules to update`)
+
+      for (const capsule of capsules) {
+        const twilightTimes = this.twilightCalculationService.calculateTwilightTimes(
+          capsule.latitude,
+          capsule.longitude,
+        )
+
+        // Update the capsule with new twilight times
+        await this.shadowCapsuleRepository.update(capsule.id, {
+          lastTwilightStart: twilightTimes.twilightStart,
+          lastTwilightEnd: twilightTimes.twilightEnd,
+          nextTwilightStart: twilightTimes.nextTwilightStart,
+          nextTwilightEnd: twilightTimes.nextTwilightEnd,
+        })
+      }
+
+      this.logger.log("Successfully updated twilight times for all shadow capsules")
+    } catch (error) {
+      this.logger.error("Error updating twilight times", error.stack)
+    }
+  }
+}

--- a/apps/capsulelabs-api/src/shadow-capsule/dto/create-shadow-capsule.dto.ts
+++ b/apps/capsulelabs-api/src/shadow-capsule/dto/create-shadow-capsule.dto.ts
@@ -1,0 +1,38 @@
+import { IsString, IsOptional, IsEnum, IsDateString, IsObject, IsNumber, Min, Max } from "class-validator"
+import { ShadowCapsuleType } from "../entities/shadow-capsule.entity"
+
+export class CreateShadowCapsuleDto {
+  @IsString()
+  title: string
+
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @IsObject()
+  content: Record<string, any>
+
+  @IsEnum(ShadowCapsuleType)
+  type: ShadowCapsuleType
+
+  @IsString()
+  userId: string
+
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  latitude: number
+
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  longitude: number
+
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/shadow-capsule/dto/shadow-capsule-response.dto.ts
+++ b/apps/capsulelabs-api/src/shadow-capsule/dto/shadow-capsule-response.dto.ts
@@ -1,0 +1,30 @@
+import type { ShadowCapsuleStatus, ShadowCapsuleType } from "../entities/shadow-capsule.entity"
+
+export class ShadowCapsuleResponseDto {
+  id: string
+  title: string
+  description?: string
+  content?: Record<string, any>
+  type: ShadowCapsuleType
+  status: ShadowCapsuleStatus
+  userId: string
+  latitude: number
+  longitude: number
+  lastTwilightStart?: Date
+  lastTwilightEnd?: Date
+  nextTwilightStart?: Date
+  nextTwilightEnd?: Date
+  unlockedAt?: Date
+  expiresAt?: Date
+  isCurrentlyUnlockable: boolean
+  timeUntilUnlockable?: string
+  metadata?: Record<string, any>
+  createdAt: Date
+  updatedAt: Date
+}
+
+export class UnlockAttemptResponseDto {
+  success: boolean
+  message: string
+  capsule?: ShadowCapsuleResponseDto
+}

--- a/apps/capsulelabs-api/src/shadow-capsule/dto/update-location.dto.ts
+++ b/apps/capsulelabs-api/src/shadow-capsule/dto/update-location.dto.ts
@@ -1,0 +1,13 @@
+import { IsNumber, Min, Max } from "class-validator"
+
+export class UpdateLocationDto {
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  latitude: number
+
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  longitude: number
+}

--- a/apps/capsulelabs-api/src/shadow-capsule/entities/shadow-capsule-interaction-log.entity.ts
+++ b/apps/capsulelabs-api/src/shadow-capsule/entities/shadow-capsule-interaction-log.entity.ts
@@ -1,0 +1,50 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, JoinColumn } from "typeorm"
+import { ShadowCapsule } from "./shadow-capsule.entity"
+
+export enum ShadowInteractionType {
+  CREATED = "created",
+  VIEWED = "viewed",
+  UNLOCK_ATTEMPTED = "unlock_attempted",
+  UNLOCKED = "unlocked",
+  EXPIRED = "expired",
+}
+
+@Entity("shadow_capsule_interaction_logs")
+export class ShadowCapsuleInteractionLog {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "uuid" })
+  capsuleId: string
+
+  @Column({
+    type: "enum",
+    enum: ShadowInteractionType,
+  })
+  type: ShadowInteractionType
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  userAgent: string
+
+  @Column({ type: "inet", nullable: true })
+  ipAddress: string
+
+  @CreateDateColumn()
+  timestamp: Date
+
+  @ManyToOne(
+    () => ShadowCapsule,
+    (capsule) => capsule.interactionLogs,
+    {
+      onDelete: "CASCADE",
+    },
+  )
+  @JoinColumn({ name: "capsuleId" })
+  capsule: ShadowCapsule
+}

--- a/apps/capsulelabs-api/src/shadow-capsule/entities/shadow-capsule.entity.ts
+++ b/apps/capsulelabs-api/src/shadow-capsule/entities/shadow-capsule.entity.ts
@@ -1,0 +1,87 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from "typeorm"
+import { ShadowCapsuleInteractionLog } from "./shadow-capsule-interaction-log.entity"
+
+export enum ShadowCapsuleStatus {
+  LOCKED = "locked",
+  UNLOCKED = "unlocked",
+  EXPIRED = "expired",
+}
+
+export enum ShadowCapsuleType {
+  TEXT = "text",
+  IMAGE = "image",
+  VIDEO = "video",
+  AUDIO = "audio",
+  MIXED = "mixed",
+}
+
+@Entity("shadow_capsules")
+export class ShadowCapsule {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "varchar", length: 255 })
+  title: string
+
+  @Column({ type: "text", nullable: true })
+  description: string
+
+  @Column({ type: "jsonb" })
+  content: Record<string, any>
+
+  @Column({
+    type: "enum",
+    enum: ShadowCapsuleType,
+    default: ShadowCapsuleType.TEXT,
+  })
+  type: ShadowCapsuleType
+
+  @Column({
+    type: "enum",
+    enum: ShadowCapsuleStatus,
+    default: ShadowCapsuleStatus.LOCKED,
+  })
+  status: ShadowCapsuleStatus
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "float" })
+  latitude: number
+
+  @Column({ type: "float" })
+  longitude: number
+
+  @Column({ type: "timestamp", nullable: true })
+  lastTwilightStart: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  lastTwilightEnd: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  nextTwilightStart: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  nextTwilightEnd: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  unlockedAt: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  expiresAt: Date
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+
+  @OneToMany(
+    () => ShadowCapsuleInteractionLog,
+    (log) => log.capsule,
+  )
+  interactionLogs: ShadowCapsuleInteractionLog[]
+}

--- a/apps/capsulelabs-api/src/shadow-capsule/services/shadow-capsule.service.ts
+++ b/apps/capsulelabs-api/src/shadow-capsule/services/shadow-capsule.service.ts
@@ -1,0 +1,238 @@
+import { Injectable, NotFoundException, BadRequestException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { ShadowCapsule, ShadowCapsuleStatus } from "../entities/shadow-capsule.entity"
+import { ShadowCapsuleInteractionLog, ShadowInteractionType } from "../entities/shadow-capsule-interaction-log.entity"
+import type { CreateShadowCapsuleDto } from "../dto/create-shadow-capsule.dto"
+import type { UpdateLocationDto } from "../dto/update-location.dto"
+import type { ShadowCapsuleResponseDto, UnlockAttemptResponseDto } from "../dto/shadow-capsule-response.dto"
+import type { TwilightCalculationService } from "./twilight-calculation.service"
+
+@Injectable()
+export class ShadowCapsuleService {
+  constructor(
+    @InjectRepository(ShadowCapsule)
+    private shadowCapsuleRepository: Repository<ShadowCapsule>,
+    @InjectRepository(ShadowCapsuleInteractionLog)
+    private interactionLogRepository: Repository<ShadowCapsuleInteractionLog>,
+    private twilightCalculationService: TwilightCalculationService,
+  ) {}
+
+  async createCapsule(createCapsuleDto: CreateShadowCapsuleDto): Promise<ShadowCapsuleResponseDto> {
+    // Calculate twilight times for the capsule's location
+    const twilightTimes = this.twilightCalculationService.calculateTwilightTimes(
+      createCapsuleDto.latitude,
+      createCapsuleDto.longitude,
+    )
+
+    const capsule = this.shadowCapsuleRepository.create({
+      ...createCapsuleDto,
+      expiresAt: createCapsuleDto.expiresAt ? new Date(createCapsuleDto.expiresAt) : null,
+      lastTwilightStart: twilightTimes.twilightStart,
+      lastTwilightEnd: twilightTimes.twilightEnd,
+      nextTwilightStart: twilightTimes.nextTwilightStart,
+      nextTwilightEnd: twilightTimes.nextTwilightEnd,
+    })
+
+    const savedCapsule = await this.shadowCapsuleRepository.save(capsule)
+
+    // Log the creation
+    await this.logInteraction(savedCapsule.userId, savedCapsule.id, ShadowInteractionType.CREATED, {
+      capsuleType: savedCapsule.type,
+      location: {
+        latitude: savedCapsule.latitude,
+        longitude: savedCapsule.longitude,
+      },
+    })
+
+    return this.mapToResponseDto(savedCapsule)
+  }
+
+  async getCapsuleById(id: string, userId: string): Promise<ShadowCapsuleResponseDto> {
+    const capsule = await this.shadowCapsuleRepository.findOne({
+      where: { id, userId },
+    })
+
+    if (!capsule) {
+      throw new NotFoundException("Shadow capsule not found")
+    }
+
+    // Update twilight times if they're outdated
+    await this.updateTwilightTimesIfNeeded(capsule)
+
+    // Log the view
+    await this.logInteraction(userId, id, ShadowInteractionType.VIEWED)
+
+    return this.mapToResponseDto(capsule)
+  }
+
+  async getUserCapsules(userId: string): Promise<ShadowCapsuleResponseDto[]> {
+    const capsules = await this.shadowCapsuleRepository.find({
+      where: { userId },
+      order: { createdAt: "DESC" },
+    })
+
+    // Update twilight times for all capsules
+    for (const capsule of capsules) {
+      await this.updateTwilightTimesIfNeeded(capsule)
+    }
+
+    return capsules.map((capsule) => this.mapToResponseDto(capsule))
+  }
+
+  async attemptUnlock(capsuleId: string, userId: string): Promise<UnlockAttemptResponseDto> {
+    const capsule = await this.shadowCapsuleRepository.findOne({
+      where: { id: capsuleId, userId },
+    })
+
+    if (!capsule) {
+      throw new NotFoundException("Shadow capsule not found")
+    }
+
+    if (capsule.status !== ShadowCapsuleStatus.LOCKED) {
+      throw new BadRequestException("Capsule is not locked")
+    }
+
+    // Update twilight times
+    await this.updateTwilightTimesIfNeeded(capsule)
+
+    // Check if current time is within twilight period
+    const isWithinTwilight = this.twilightCalculationService.isCurrentlyTwilight(capsule.latitude, capsule.longitude)
+
+    // Log the attempt
+    await this.logInteraction(userId, capsuleId, ShadowInteractionType.UNLOCK_ATTEMPTED, {
+      isWithinTwilight,
+      twilightStart: capsule.lastTwilightStart,
+      twilightEnd: capsule.lastTwilightEnd,
+    })
+
+    if (!isWithinTwilight) {
+      const timeUntilNext = this.twilightCalculationService.getTimeUntilNextTwilight(
+        capsule.latitude,
+        capsule.longitude,
+      )
+
+      return {
+        success: false,
+        message: `Capsule can only be unlocked during twilight hours. Next twilight in ${timeUntilNext.formatted}.`,
+      }
+    }
+
+    // Unlock the capsule
+    capsule.status = ShadowCapsuleStatus.UNLOCKED
+    capsule.unlockedAt = new Date()
+    await this.shadowCapsuleRepository.save(capsule)
+
+    // Log successful unlock
+    await this.logInteraction(userId, capsuleId, ShadowInteractionType.UNLOCKED)
+
+    return {
+      success: true,
+      message: "Capsule unlocked successfully!",
+      capsule: this.mapToResponseDto(capsule),
+    }
+  }
+
+  async updateLocation(
+    capsuleId: string,
+    userId: string,
+    updateLocationDto: UpdateLocationDto,
+  ): Promise<ShadowCapsuleResponseDto> {
+    const capsule = await this.shadowCapsuleRepository.findOne({
+      where: { id: capsuleId, userId },
+    })
+
+    if (!capsule) {
+      throw new NotFoundException("Shadow capsule not found")
+    }
+
+    if (capsule.status !== ShadowCapsuleStatus.LOCKED) {
+      throw new BadRequestException("Cannot update location of an unlocked or expired capsule")
+    }
+
+    // Update location
+    capsule.latitude = updateLocationDto.latitude
+    capsule.longitude = updateLocationDto.longitude
+
+    // Recalculate twilight times
+    const twilightTimes = this.twilightCalculationService.calculateTwilightTimes(
+      updateLocationDto.latitude,
+      updateLocationDto.longitude,
+    )
+
+    capsule.lastTwilightStart = twilightTimes.twilightStart
+    capsule.lastTwilightEnd = twilightTimes.twilightEnd
+    capsule.nextTwilightStart = twilightTimes.nextTwilightStart
+    capsule.nextTwilightEnd = twilightTimes.nextTwilightEnd
+
+    const updatedCapsule = await this.shadowCapsuleRepository.save(capsule)
+
+    return this.mapToResponseDto(updatedCapsule)
+  }
+
+  private async updateTwilightTimesIfNeeded(capsule: ShadowCapsule): Promise<void> {
+    const now = new Date()
+
+    // If next twilight end is in the past, we need to update the twilight times
+    if (!capsule.nextTwilightEnd || capsule.nextTwilightEnd < now) {
+      const twilightTimes = this.twilightCalculationService.calculateTwilightTimes(capsule.latitude, capsule.longitude)
+
+      capsule.lastTwilightStart = twilightTimes.twilightStart
+      capsule.lastTwilightEnd = twilightTimes.twilightEnd
+      capsule.nextTwilightStart = twilightTimes.nextTwilightStart
+      capsule.nextTwilightEnd = twilightTimes.nextTwilightEnd
+
+      await this.shadowCapsuleRepository.save(capsule)
+    }
+  }
+
+  private async logInteraction(
+    userId: string,
+    capsuleId: string,
+    type: ShadowInteractionType,
+    metadata?: Record<string, any>,
+  ): Promise<void> {
+    const log = this.interactionLogRepository.create({
+      userId,
+      capsuleId,
+      type,
+      metadata,
+    })
+
+    await this.interactionLogRepository.save(log)
+  }
+
+  private mapToResponseDto(capsule: ShadowCapsule): ShadowCapsuleResponseDto {
+    const isCurrentlyUnlockable = this.twilightCalculationService.isCurrentlyTwilight(
+      capsule.latitude,
+      capsule.longitude,
+    )
+
+    const timeUntilUnlockable = !isCurrentlyUnlockable
+      ? this.twilightCalculationService.getTimeUntilNextTwilight(capsule.latitude, capsule.longitude).formatted
+      : undefined
+
+    return {
+      id: capsule.id,
+      title: capsule.title,
+      description: capsule.description,
+      content: capsule.status === ShadowCapsuleStatus.UNLOCKED ? capsule.content : undefined,
+      type: capsule.type,
+      status: capsule.status,
+      userId: capsule.userId,
+      latitude: capsule.latitude,
+      longitude: capsule.longitude,
+      lastTwilightStart: capsule.lastTwilightStart,
+      lastTwilightEnd: capsule.lastTwilightEnd,
+      nextTwilightStart: capsule.nextTwilightStart,
+      nextTwilightEnd: capsule.nextTwilightEnd,
+      unlockedAt: capsule.unlockedAt,
+      expiresAt: capsule.expiresAt,
+      isCurrentlyUnlockable,
+      timeUntilUnlockable,
+      metadata: capsule.metadata,
+      createdAt: capsule.createdAt,
+      updatedAt: capsule.updatedAt,
+    }
+  }
+}

--- a/apps/capsulelabs-api/src/shadow-capsule/services/twilight-calculation.service.ts
+++ b/apps/capsulelabs-api/src/shadow-capsule/services/twilight-calculation.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from "@nestjs/common"
+import * as SunCalc from "suncalc"
+
+export interface TwilightTimes {
+  twilightStart: Date // Start of twilight (golden hour begin)
+  twilightEnd: Date // End of twilight (dusk)
+  nextTwilightStart: Date // Next day's twilight start
+  nextTwilightEnd: Date // Next day's twilight end
+}
+
+@Injectable()
+export class TwilightCalculationService {
+  /**
+   * Calculate twilight times for a specific location and date
+   * Twilight is defined as the period between golden hour start and dusk
+   */
+  calculateTwilightTimes(latitude: number, longitude: number, date: Date = new Date()): TwilightTimes {
+    // Get today's sun times
+    const todaySunTimes = SunCalc.getTimes(date, latitude, longitude)
+
+    // Golden hour start is when the soft light begins
+    const twilightStart = todaySunTimes.goldenHour
+
+    // Dusk is when the sun has completely set and darkness begins
+    const twilightEnd = todaySunTimes.dusk
+
+    // Calculate tomorrow's twilight times
+    const tomorrow = new Date(date)
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    const tomorrowSunTimes = SunCalc.getTimes(tomorrow, latitude, longitude)
+
+    return {
+      twilightStart,
+      twilightEnd,
+      nextTwilightStart: tomorrowSunTimes.goldenHour,
+      nextTwilightEnd: tomorrowSunTimes.dusk,
+    }
+  }
+
+  /**
+   * Check if the current time is within twilight hours
+   */
+  isCurrentlyTwilight(latitude: number, longitude: number): boolean {
+    const now = new Date()
+    const { twilightStart, twilightEnd } = this.calculateTwilightTimes(latitude, longitude, now)
+
+    return now >= twilightStart && now <= twilightEnd
+  }
+
+  /**
+   * Get time remaining until next twilight period
+   */
+  getTimeUntilNextTwilight(
+    latitude: number,
+    longitude: number,
+  ): {
+    milliseconds: number
+    formatted: string
+  } {
+    const now = new Date()
+    const { twilightStart, twilightEnd, nextTwilightStart } = this.calculateTwilightTimes(latitude, longitude, now)
+
+    let targetTime: Date
+
+    // If we're before today's twilight, target is today's twilight start
+    if (now < twilightStart) {
+      targetTime = twilightStart
+    }
+    // If we're after today's twilight, target is tomorrow's twilight start
+    else if (now > twilightEnd) {
+      targetTime = nextTwilightStart
+    }
+    // We're currently in twilight, so time remaining is 0
+    else {
+      return { milliseconds: 0, formatted: "Currently in twilight" }
+    }
+
+    const milliseconds = targetTime.getTime() - now.getTime()
+
+    // Format the time difference
+    const hours = Math.floor(milliseconds / (1000 * 60 * 60))
+    const minutes = Math.floor((milliseconds % (1000 * 60 * 60)) / (1000 * 60))
+
+    return {
+      milliseconds,
+      formatted: `${hours} hours and ${minutes} minutes`,
+    }
+  }
+}

--- a/apps/capsulelabs-api/src/shadow-capsule/shadow-capsule.module.ts
+++ b/apps/capsulelabs-api/src/shadow-capsule/shadow-capsule.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { ShadowCapsuleController } from "./controllers/shadow-capsule.controller"
+import { ShadowCapsuleService } from "./services/shadow-capsule.service"
+import { TwilightCalculationService } from "./services/twilight-calculation.service"
+import { ShadowCapsule } from "./entities/shadow-capsule.entity"
+import { ShadowCapsuleInteractionLog } from "./entities/shadow-capsule-interaction-log.entity"
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ShadowCapsule, ShadowCapsuleInteractionLog])],
+  controllers: [ShadowCapsuleController],
+  providers: [ShadowCapsuleService, TwilightCalculationService],
+  exports: [ShadowCapsuleService, TwilightCalculationService],
+})
+export class ShadowCapsuleModule {}

--- a/apps/capsulelabs-api/src/shadow-capsule/tests/twilight-calculation.service.spec.ts
+++ b/apps/capsulelabs-api/src/shadow-capsule/tests/twilight-calculation.service.spec.ts
@@ -1,0 +1,118 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { TwilightCalculationService } from "../services/twilight-calculation.service"
+import * as SunCalc from "suncalc"
+
+jest.mock("suncalc", () => ({
+  getTimes: jest.fn(),
+}))
+
+describe("TwilightCalculationService", () => {
+  let service: TwilightCalculationService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TwilightCalculationService],
+    }).compile()
+
+    service = module.get<TwilightCalculationService>(TwilightCalculationService)
+  })
+
+  it("should be defined", () => {
+    expect(service).toBeDefined()
+  })
+
+  describe("calculateTwilightTimes", () => {
+    it("should calculate twilight times correctly", () => {
+      // Mock the SunCalc.getTimes function
+      const mockDate = new Date("2023-01-01T12:00:00Z")
+      const mockTomorrowDate = new Date("2023-01-02T12:00:00Z")
+
+      const mockTodayTimes = {
+        goldenHour: new Date("2023-01-01T18:00:00Z"),
+        dusk: new Date("2023-01-01T19:30:00Z"),
+      }
+
+      const mockTomorrowTimes = {
+        goldenHour: new Date("2023-01-02T18:00:00Z"),
+        dusk: new Date("2023-01-02T19:30:00Z"),
+      }
+      ;(SunCalc.getTimes as jest.Mock).mockImplementation((date) => {
+        if (date.getDate() === mockDate.getDate()) {
+          return mockTodayTimes
+        } else {
+          return mockTomorrowTimes
+        }
+      })
+
+      const result = service.calculateTwilightTimes(40.7128, -74.006, mockDate)
+
+      expect(result).toEqual({
+        twilightStart: mockTodayTimes.goldenHour,
+        twilightEnd: mockTodayTimes.dusk,
+        nextTwilightStart: mockTomorrowTimes.goldenHour,
+        nextTwilightEnd: mockTomorrowTimes.dusk,
+      })
+
+      expect(SunCalc.getTimes).toHaveBeenCalledTimes(2)
+      expect(SunCalc.getTimes).toHaveBeenCalledWith(mockDate, 40.7128, -74.006)
+      expect(SunCalc.getTimes).toHaveBeenCalledWith(mockTomorrowDate, 40.7128, -74.006)
+    })
+  })
+
+  describe("isCurrentlyTwilight", () => {
+    it("should return true when current time is within twilight", () => {
+      // Mock the current time to be within twilight
+      const mockNow = new Date("2023-01-01T18:30:00Z")
+      jest.spyOn(global, "Date").mockImplementation(() => mockNow as unknown as string)
+
+      // Mock the calculateTwilightTimes method
+      jest.spyOn(service, "calculateTwilightTimes").mockReturnValue({
+        twilightStart: new Date("2023-01-01T18:00:00Z"),
+        twilightEnd: new Date("2023-01-01T19:30:00Z"),
+        nextTwilightStart: new Date("2023-01-02T18:00:00Z"),
+        nextTwilightEnd: new Date("2023-01-02T19:30:00Z"),
+      })
+
+      const result = service.isCurrentlyTwilight(40.7128, -74.006)
+
+      expect(result).toBe(true)
+      expect(service.calculateTwilightTimes).toHaveBeenCalledWith(40.7128, -74.006, mockNow)
+    })
+
+    it("should return false when current time is before twilight", () => {
+      // Mock the current time to be before twilight
+      const mockNow = new Date("2023-01-01T17:30:00Z")
+      jest.spyOn(global, "Date").mockImplementation(() => mockNow as unknown as string)
+
+      // Mock the calculateTwilightTimes method
+      jest.spyOn(service, "calculateTwilightTimes").mockReturnValue({
+        twilightStart: new Date("2023-01-01T18:00:00Z"),
+        twilightEnd: new Date("2023-01-01T19:30:00Z"),
+        nextTwilightStart: new Date("2023-01-02T18:00:00Z"),
+        nextTwilightEnd: new Date("2023-01-02T19:30:00Z"),
+      })
+
+      const result = service.isCurrentlyTwilight(40.7128, -74.006)
+
+      expect(result).toBe(false)
+    })
+
+    it("should return false when current time is after twilight", () => {
+      // Mock the current time to be after twilight
+      const mockNow = new Date("2023-01-01T20:00:00Z")
+      jest.spyOn(global, "Date").mockImplementation(() => mockNow as unknown as string)
+
+      // Mock the calculateTwilightTimes method
+      jest.spyOn(service, "calculateTwilightTimes").mockReturnValue({
+        twilightStart: new Date("2023-01-01T18:00:00Z"),
+        twilightEnd: new Date("2023-01-01T19:30:00Z"),
+        nextTwilightStart: new Date("2023-01-02T18:00:00Z"),
+        nextTwilightEnd: new Date("2023-01-02T19:30:00Z"),
+      })
+
+      const result = service.isCurrentlyTwilight(40.7128, -74.006)
+
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/apps/capsulelabs-api/src/streak-capsule/controllers/streak-capsule.controller.ts
+++ b/apps/capsulelabs-api/src/streak-capsule/controllers/streak-capsule.controller.ts
@@ -1,0 +1,62 @@
+import { Controller, Get, Post, Body, Param, Query, ParseUUIDPipe, ValidationPipe, ParseIntPipe } from "@nestjs/common"
+import type { StreakCapsuleService } from "../services/streak-capsule.service"
+import type { CreateStreakCapsuleDto } from "../dto/create-streak-capsule.dto"
+import type { CheckInDto } from "../dto/check-in.dto"
+import type { StreakCapsuleResponseDto, CheckInResponseDto, StreakStatsDto } from "../dto/streak-capsule-response.dto"
+import type { DailyCheckIn } from "../entities/daily-check-in.entity"
+
+// Note: You'll need to implement your own authentication guard
+// import { AuthGuard } from '@nestjs/passport';
+// import { GetUser } from '../auth/get-user.decorator';
+
+@Controller("streak-capsules")
+// @UseGuards(AuthGuard())
+export class StreakCapsuleController {
+  constructor(private readonly streakCapsuleService: StreakCapsuleService) {}
+
+  @Post()
+  async createCapsule(
+    @Body() createCapsuleDto: CreateStreakCapsuleDto,
+  ): Promise<StreakCapsuleResponseDto> {
+    return await this.streakCapsuleService.createCapsule(createCapsuleDto)
+  }
+
+  @Get()
+  async getUserCapsules(
+    @Query('userId') userId: string,
+  ): Promise<StreakCapsuleResponseDto[]> {
+    return await this.streakCapsuleService.getUserCapsules(userId)
+  }
+
+  @Get(":id")
+  async getCapsuleById(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('userId') userId: string,
+  ): Promise<StreakCapsuleResponseDto> {
+    return await this.streakCapsuleService.getCapsuleById(id, userId)
+  }
+
+  @Post("check-in")
+  async checkIn(
+    @Query('userId') userId: string,
+    @Body(ValidationPipe) checkInDto: CheckInDto,
+  ): Promise<CheckInResponseDto> {
+    return await this.streakCapsuleService.checkIn(userId, checkInDto)
+  }
+
+  @Get("stats/:userId")
+  async getStreakStats(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Query('timezone') timezone?: string,
+  ): Promise<StreakStatsDto> {
+    return await this.streakCapsuleService.getStreakStats(userId, timezone)
+  }
+
+  @Get("check-ins/:userId")
+  async getUserCheckIns(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Query('limit', new ParseIntPipe({ optional: true })) limit?: number,
+  ): Promise<DailyCheckIn[]> {
+    return await this.streakCapsuleService.getUserCheckIns(userId, limit)
+  }
+}

--- a/apps/capsulelabs-api/src/streak-capsule/cron/streak-maintenance.cron.ts
+++ b/apps/capsulelabs-api/src/streak-capsule/cron/streak-maintenance.cron.ts
@@ -1,0 +1,115 @@
+import { Injectable } from "@nestjs/common"
+import { Cron, CronExpression } from "@nestjs/schedule"
+import type { Repository } from "typeorm"
+import { type StreakCapsule, StreakCapsuleStatus } from "../entities/streak-capsule.entity"
+import {
+  type StreakCapsuleInteractionLog,
+  StreakInteractionType,
+} from "../entities/streak-capsule-interaction-log.entity"
+import type { StreakCalculationService } from "../services/streak-calculation.service"
+import { Logger } from "@nestjs/common"
+
+@Injectable()
+export class StreakMaintenanceCron {
+  private readonly logger = new Logger(StreakMaintenanceCron.name)
+
+  constructor(
+    private streakCalculationService: StreakCalculationService,
+    private streakCapsuleRepository: Repository<StreakCapsule>,
+    private interactionLogRepository: Repository<StreakCapsuleInteractionLog>,
+  ) {}
+
+  /**
+   * Check all active streak capsules daily to update streak status
+   * This ensures that broken streaks are detected and logged
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async updateAllStreakStatuses() {
+    this.logger.log("Starting daily streak status update")
+
+    try {
+      // Get all locked streak capsules
+      const capsules = await this.streakCapsuleRepository.find({
+        where: { status: StreakCapsuleStatus.LOCKED },
+      })
+
+      this.logger.log(`Found ${capsules.length} locked streak capsules to check`)
+
+      for (const capsule of capsules) {
+        try {
+          const streakUpdate = await this.streakCalculationService.updateCapsuleStreak(capsule)
+
+          // Check if streak was broken
+          if (streakUpdate.isStreakBroken) {
+            // Log the broken streak
+            await this.logInteraction(capsule.userId, capsule.id, StreakInteractionType.STREAK_BROKEN, {
+              previousStreak: capsule.currentStreak,
+              newStreak: streakUpdate.currentStreak,
+              brokenAt: new Date(),
+            })
+
+            this.logger.log(`Streak broken for capsule ${capsule.id}, user ${capsule.userId}`)
+          }
+
+          // Update capsule data
+          capsule.currentStreak = streakUpdate.currentStreak
+          capsule.longestStreak = streakUpdate.longestStreak
+          capsule.totalCheckIns = streakUpdate.totalCheckIns
+
+          // Reset streak start date if streak is broken
+          if (streakUpdate.currentStreak === 0) {
+            capsule.streakStartDate = null
+          }
+
+          await this.streakCapsuleRepository.save(capsule)
+        } catch (error) {
+          this.logger.error(`Error updating streak for capsule ${capsule.id}:`, error.stack)
+        }
+      }
+
+      this.logger.log("Successfully completed daily streak status update")
+    } catch (error) {
+      this.logger.error("Error during daily streak status update:", error.stack)
+    }
+  }
+
+  /**
+   * Clean up old interaction logs to prevent database bloat
+   * Runs weekly to remove logs older than 1 year
+   */
+  @Cron(CronExpression.EVERY_WEEK)
+  async cleanupOldLogs() {
+    this.logger.log("Starting weekly log cleanup")
+
+    try {
+      const oneYearAgo = new Date()
+      oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1)
+
+      const result = await this.interactionLogRepository
+        .createQueryBuilder()
+        .delete()
+        .where("timestamp < :date", { date: oneYearAgo })
+        .execute()
+
+      this.logger.log(`Cleaned up ${result.affected} old interaction logs`)
+    } catch (error) {
+      this.logger.error("Error during log cleanup:", error.stack)
+    }
+  }
+
+  private async logInteraction(
+    userId: string,
+    capsuleId: string,
+    type: StreakInteractionType,
+    metadata?: Record<string, any>,
+  ): Promise<void> {
+    const log = this.interactionLogRepository.create({
+      userId,
+      capsuleId,
+      type,
+      metadata,
+    })
+
+    await this.interactionLogRepository.save(log)
+  }
+}

--- a/apps/capsulelabs-api/src/streak-capsule/dto/check-in.dto.ts
+++ b/apps/capsulelabs-api/src/streak-capsule/dto/check-in.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString, IsObject } from "class-validator"
+
+export class CheckInDto {
+  @IsOptional()
+  @IsString()
+  timezone?: string
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/streak-capsule/dto/create-streak-capsule.dto.ts
+++ b/apps/capsulelabs-api/src/streak-capsule/dto/create-streak-capsule.dto.ts
@@ -1,0 +1,47 @@
+import { IsString, IsOptional, IsEnum, IsDateString, IsObject, IsInt, Min, Max, IsBoolean } from "class-validator"
+import { StreakCapsuleType } from "../entities/streak-capsule.entity"
+
+export class CreateStreakCapsuleDto {
+  @IsString()
+  title: string
+
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @IsObject()
+  content: Record<string, any>
+
+  @IsEnum(StreakCapsuleType)
+  type: StreakCapsuleType
+
+  @IsString()
+  userId: string
+
+  @IsInt()
+  @Min(1)
+  @Max(365)
+  requiredStreakDays: number
+
+  @IsOptional()
+  @IsString()
+  timezone?: string
+
+  @IsOptional()
+  @IsBoolean()
+  allowGracePeriod?: boolean
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(48)
+  gracePeriodHours?: number
+
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/apps/capsulelabs-api/src/streak-capsule/dto/streak-capsule-response.dto.ts
+++ b/apps/capsulelabs-api/src/streak-capsule/dto/streak-capsule-response.dto.ts
@@ -1,0 +1,47 @@
+import type { StreakCapsuleStatus, StreakCapsuleType } from "../entities/streak-capsule.entity"
+
+export class StreakCapsuleResponseDto {
+  id: string
+  title: string
+  description?: string
+  content?: Record<string, any>
+  type: StreakCapsuleType
+  status: StreakCapsuleStatus
+  userId: string
+  requiredStreakDays: number
+  currentStreak: number
+  longestStreak: number
+  totalCheckIns: number
+  lastCheckInDate?: Date
+  streakStartDate?: Date
+  timezone: string
+  allowGracePeriod: boolean
+  gracePeriodHours: number
+  unlockedAt?: Date
+  expiresAt?: Date
+  metadata?: Record<string, any>
+  createdAt: Date
+  updatedAt: Date
+  progressPercentage: number
+  daysRemaining: number
+  canCheckInToday: boolean
+  isStreakActive: boolean
+}
+
+export class CheckInResponseDto {
+  success: boolean
+  message: string
+  currentStreak: number
+  isNewRecord: boolean
+  capsuleUnlocked?: boolean
+  streakCapsule?: StreakCapsuleResponseDto
+}
+
+export class StreakStatsDto {
+  currentStreak: number
+  longestStreak: number
+  totalCheckIns: number
+  lastCheckInDate?: Date
+  streakStartDate?: Date
+  isStreakActive: boolean
+}

--- a/apps/capsulelabs-api/src/streak-capsule/entities/daily-check-in.entity.ts
+++ b/apps/capsulelabs-api/src/streak-capsule/entities/daily-check-in.entity.ts
@@ -1,0 +1,29 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from "typeorm"
+
+@Entity("daily_check_ins")
+@Index(["userId", "checkInDate"], { unique: true })
+export class DailyCheckIn {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "date" })
+  checkInDate: Date
+
+  @Column({ type: "varchar", length: 50, default: "UTC" })
+  timezone: string
+
+  @Column({ type: "int", default: 1 })
+  streakDay: number
+
+  @Column({ type: "boolean", default: false })
+  isGracePeriod: boolean
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @CreateDateColumn()
+  createdAt: Date
+}

--- a/apps/capsulelabs-api/src/streak-capsule/entities/streak-capsule-interaction-log.entity.ts
+++ b/apps/capsulelabs-api/src/streak-capsule/entities/streak-capsule-interaction-log.entity.ts
@@ -1,0 +1,52 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, JoinColumn } from "typeorm"
+import { StreakCapsule } from "./streak-capsule.entity"
+
+export enum StreakInteractionType {
+  CREATED = "created",
+  VIEWED = "viewed",
+  CHECK_IN = "check_in",
+  STREAK_BROKEN = "streak_broken",
+  STREAK_COMPLETED = "streak_completed",
+  UNLOCKED = "unlocked",
+  EXPIRED = "expired",
+}
+
+@Entity("streak_capsule_interaction_logs")
+export class StreakCapsuleInteractionLog {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "uuid" })
+  capsuleId: string
+
+  @Column({
+    type: "enum",
+    enum: StreakInteractionType,
+  })
+  type: StreakInteractionType
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  userAgent: string
+
+  @Column({ type: "inet", nullable: true })
+  ipAddress: string
+
+  @CreateDateColumn()
+  timestamp: Date
+
+  @ManyToOne(
+    () => StreakCapsule,
+    (capsule) => capsule.interactionLogs,
+    {
+      onDelete: "CASCADE",
+    },
+  )
+  @JoinColumn({ name: "capsuleId" })
+  capsule: StreakCapsule
+}

--- a/apps/capsulelabs-api/src/streak-capsule/entities/streak-capsule.entity.ts
+++ b/apps/capsulelabs-api/src/streak-capsule/entities/streak-capsule.entity.ts
@@ -1,0 +1,96 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from "typeorm"
+import { StreakCapsuleInteractionLog } from "./streak-capsule-interaction-log.entity"
+
+export enum StreakCapsuleStatus {
+  LOCKED = "locked",
+  UNLOCKED = "unlocked",
+  EXPIRED = "expired",
+}
+
+export enum StreakCapsuleType {
+  TEXT = "text",
+  IMAGE = "image",
+  VIDEO = "video",
+  AUDIO = "audio",
+  MIXED = "mixed",
+}
+
+@Entity("streak_capsules")
+export class StreakCapsule {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "varchar", length: 255 })
+  title: string
+
+  @Column({ type: "text", nullable: true })
+  description: string
+
+  @Column({ type: "jsonb" })
+  content: Record<string, any>
+
+  @Column({
+    type: "enum",
+    enum: StreakCapsuleType,
+    default: StreakCapsuleType.TEXT,
+  })
+  type: StreakCapsuleType
+
+  @Column({
+    type: "enum",
+    enum: StreakCapsuleStatus,
+    default: StreakCapsuleStatus.LOCKED,
+  })
+  status: StreakCapsuleStatus
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({ type: "int" })
+  requiredStreakDays: number
+
+  @Column({ type: "int", default: 0 })
+  currentStreak: number
+
+  @Column({ type: "int", default: 0 })
+  longestStreak: number
+
+  @Column({ type: "int", default: 0 })
+  totalCheckIns: number
+
+  @Column({ type: "date", nullable: true })
+  lastCheckInDate: Date
+
+  @Column({ type: "date", nullable: true })
+  streakStartDate: Date
+
+  @Column({ type: "varchar", length: 50, default: "UTC" })
+  timezone: string
+
+  @Column({ type: "boolean", default: false })
+  allowGracePeriod: boolean
+
+  @Column({ type: "int", default: 0 })
+  gracePeriodHours: number
+
+  @Column({ type: "timestamp", nullable: true })
+  unlockedAt: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  expiresAt: Date
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+
+  @OneToMany(
+    () => StreakCapsuleInteractionLog,
+    (log) => log.capsule,
+  )
+  interactionLogs: StreakCapsuleInteractionLog[]
+}

--- a/apps/capsulelabs-api/src/streak-capsule/services/check-in.service.ts
+++ b/apps/capsulelabs-api/src/streak-capsule/services/check-in.service.ts
@@ -1,0 +1,227 @@
+import { Injectable, BadRequestException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { DailyCheckIn } from "../entities/daily-check-in.entity"
+import type { StreakStatsDto } from "../dto/streak-capsule-response.dto"
+
+@Injectable()
+export class CheckInService {
+  constructor(
+    @InjectRepository(DailyCheckIn)
+    private checkInRepository: Repository<DailyCheckIn>,
+  ) {}
+
+  async checkIn(
+    userId: string,
+    timezone = "UTC",
+    metadata?: Record<string, any>,
+  ): Promise<{ checkIn: DailyCheckIn; isNewRecord: boolean }> {
+    const today = this.getTodayInTimezone(timezone)
+
+    // Check if user already checked in today
+    const existingCheckIn = await this.checkInRepository.findOne({
+      where: {
+        userId,
+        checkInDate: today,
+      },
+    })
+
+    if (existingCheckIn) {
+      throw new BadRequestException("Already checked in today")
+    }
+
+    // Get yesterday's check-in to determine streak
+    const yesterday = new Date(today)
+    yesterday.setDate(yesterday.getDate() - 1)
+
+    const yesterdayCheckIn = await this.checkInRepository.findOne({
+      where: {
+        userId,
+        checkInDate: yesterday,
+      },
+    })
+
+    // Calculate streak day
+    let streakDay = 1
+    if (yesterdayCheckIn) {
+      streakDay = yesterdayCheckIn.streakDay + 1
+    }
+
+    // Create new check-in
+    const checkIn = this.checkInRepository.create({
+      userId,
+      checkInDate: today,
+      timezone,
+      streakDay,
+      metadata,
+    })
+
+    const savedCheckIn = await this.checkInRepository.save(checkIn)
+
+    // Check if this is a new record
+    const longestStreak = await this.getLongestStreak(userId)
+    const isNewRecord = streakDay > longestStreak
+
+    return { checkIn: savedCheckIn, isNewRecord }
+  }
+
+  async getStreakStats(userId: string, timezone = "UTC"): Promise<StreakStatsDto> {
+    const today = this.getTodayInTimezone(timezone)
+
+    // Get current streak
+    const currentStreak = await this.getCurrentStreak(userId, today)
+
+    // Get longest streak
+    const longestStreak = await this.getLongestStreak(userId)
+
+    // Get total check-ins
+    const totalCheckIns = await this.checkInRepository.count({
+      where: { userId },
+    })
+
+    // Get last check-in date
+    const lastCheckIn = await this.checkInRepository.findOne({
+      where: { userId },
+      order: { checkInDate: "DESC" },
+    })
+
+    // Get streak start date (first day of current streak)
+    let streakStartDate: Date | undefined
+    if (currentStreak > 0) {
+      const streakStart = new Date(today)
+      streakStart.setDate(streakStart.getDate() - currentStreak + 1)
+      streakStartDate = streakStart
+    }
+
+    // Check if streak is active (checked in today or yesterday)
+    const yesterday = new Date(today)
+    yesterday.setDate(yesterday.getDate() - 1)
+
+    const isStreakActive =
+      lastCheckIn &&
+      (this.isSameDate(lastCheckIn.checkInDate, today) || this.isSameDate(lastCheckIn.checkInDate, yesterday))
+
+    return {
+      currentStreak,
+      longestStreak,
+      totalCheckIns,
+      lastCheckInDate: lastCheckIn?.checkInDate,
+      streakStartDate,
+      isStreakActive: !!isStreakActive,
+    }
+  }
+
+  async getCurrentStreak(userId: string, referenceDate: Date): Promise<number> {
+    // Get all check-ins in descending order
+    const checkIns = await this.checkInRepository.find({
+      where: { userId },
+      order: { checkInDate: "DESC" },
+    })
+
+    if (checkIns.length === 0) {
+      return 0
+    }
+
+    let streak = 0
+    const currentDate = new Date(referenceDate)
+
+    // Check if user checked in today
+    if (this.isSameDate(checkIns[0].checkInDate, currentDate)) {
+      streak = 1
+      currentDate.setDate(currentDate.getDate() - 1)
+    }
+    // If not checked in today, check if checked in yesterday
+    else {
+      currentDate.setDate(currentDate.getDate() - 1)
+      if (!this.isSameDate(checkIns[0].checkInDate, currentDate)) {
+        return 0 // Streak is broken
+      }
+      streak = 1
+      currentDate.setDate(currentDate.getDate() - 1)
+    }
+
+    // Count consecutive days
+    for (let i = 1; i < checkIns.length; i++) {
+      if (this.isSameDate(checkIns[i].checkInDate, currentDate)) {
+        streak++
+        currentDate.setDate(currentDate.getDate() - 1)
+      } else {
+        break
+      }
+    }
+
+    return streak
+  }
+
+  async getLongestStreak(userId: string): Promise<number> {
+    const checkIns = await this.checkInRepository.find({
+      where: { userId },
+      order: { checkInDate: "ASC" },
+    })
+
+    if (checkIns.length === 0) {
+      return 0
+    }
+
+    let longestStreak = 1
+    let currentStreak = 1
+
+    for (let i = 1; i < checkIns.length; i++) {
+      const prevDate = new Date(checkIns[i - 1].checkInDate)
+      const currentDate = new Date(checkIns[i].checkInDate)
+
+      // Check if dates are consecutive
+      prevDate.setDate(prevDate.getDate() + 1)
+
+      if (this.isSameDate(prevDate, currentDate)) {
+        currentStreak++
+        longestStreak = Math.max(longestStreak, currentStreak)
+      } else {
+        currentStreak = 1
+      }
+    }
+
+    return longestStreak
+  }
+
+  async canCheckInToday(userId: string, timezone = "UTC"): Promise<boolean> {
+    const today = this.getTodayInTimezone(timezone)
+
+    const existingCheckIn = await this.checkInRepository.findOne({
+      where: {
+        userId,
+        checkInDate: today,
+      },
+    })
+
+    return !existingCheckIn
+  }
+
+  async getUserCheckIns(userId: string, limit = 30): Promise<DailyCheckIn[]> {
+    return await this.checkInRepository.find({
+      where: { userId },
+      order: { checkInDate: "DESC" },
+      take: limit,
+    })
+  }
+
+  private getTodayInTimezone(timezone: string): Date {
+    const now = new Date()
+    const utc = now.getTime() + now.getTimezoneOffset() * 60000
+
+    // Get timezone offset (this is a simplified approach)
+    // In a real application, you might want to use a library like moment-timezone
+    const targetTime = new Date(utc)
+
+    // Return just the date part
+    return new Date(targetTime.getFullYear(), targetTime.getMonth(), targetTime.getDate())
+  }
+
+  private isSameDate(date1: Date, date2: Date): boolean {
+    return (
+      date1.getFullYear() === date2.getFullYear() &&
+      date1.getMonth() === date2.getMonth() &&
+      date1.getDate() === date2.getDate()
+    )
+  }
+}

--- a/apps/capsulelabs-api/src/streak-capsule/services/streak-calculation.service.ts
+++ b/apps/capsulelabs-api/src/streak-capsule/services/streak-calculation.service.ts
@@ -1,0 +1,99 @@
+import { Injectable } from "@nestjs/common"
+import type { StreakCapsule } from "../entities/streak-capsule.entity"
+import type { CheckInService } from "./check-in.service"
+
+@Injectable()
+export class StreakCalculationService {
+  constructor(private checkInService: CheckInService) {}
+
+  async updateCapsuleStreak(capsule: StreakCapsule): Promise<{
+    currentStreak: number
+    longestStreak: number
+    totalCheckIns: number
+    isStreakComplete: boolean
+    isStreakBroken: boolean
+  }> {
+    const stats = await this.checkInService.getStreakStats(capsule.userId, capsule.timezone)
+
+    const previousStreak = capsule.currentStreak
+    const isStreakBroken = stats.currentStreak < previousStreak && previousStreak > 0
+    const isStreakComplete = stats.currentStreak >= capsule.requiredStreakDays && !capsule.unlockedAt
+
+    return {
+      currentStreak: stats.currentStreak,
+      longestStreak: Math.max(stats.longestStreak, capsule.longestStreak),
+      totalCheckIns: stats.totalCheckIns,
+      isStreakComplete,
+      isStreakBroken,
+    }
+  }
+
+  calculateProgressPercentage(currentStreak: number, requiredStreak: number): number {
+    if (requiredStreak === 0) return 100
+    return Math.min((currentStreak / requiredStreak) * 100, 100)
+  }
+
+  calculateDaysRemaining(currentStreak: number, requiredStreak: number): number {
+    return Math.max(requiredStreak - currentStreak, 0)
+  }
+
+  isWithinGracePeriod(lastCheckInDate: Date | null, gracePeriodHours: number, timezone = "UTC"): boolean {
+    if (!lastCheckInDate || gracePeriodHours === 0) {
+      return false
+    }
+
+    const now = new Date()
+    const gracePeriodEnd = new Date(lastCheckInDate)
+    gracePeriodEnd.setHours(gracePeriodEnd.getHours() + 24 + gracePeriodHours)
+
+    return now <= gracePeriodEnd
+  }
+
+  getStreakStatus(
+    currentStreak: number,
+    requiredStreak: number,
+    lastCheckInDate: Date | null,
+    allowGracePeriod: boolean,
+    gracePeriodHours: number,
+    timezone: string,
+  ): {
+    isActive: boolean
+    isComplete: boolean
+    isBroken: boolean
+    isInGracePeriod: boolean
+  } {
+    const today = new Date()
+    const yesterday = new Date(today)
+    yesterday.setDate(yesterday.getDate() - 1)
+
+    const isComplete = currentStreak >= requiredStreak
+    const isInGracePeriod = allowGracePeriod && this.isWithinGracePeriod(lastCheckInDate, gracePeriodHours, timezone)
+
+    let isActive = false
+    let isBroken = false
+
+    if (lastCheckInDate) {
+      const lastCheckIn = new Date(lastCheckInDate)
+      const isTodayOrYesterday =
+        this.isSameDate(lastCheckIn, today) || this.isSameDate(lastCheckIn, yesterday) || isInGracePeriod
+
+      isActive = isTodayOrYesterday
+      isBroken = !isActive && currentStreak > 0
+    }
+
+    return {
+      isActive,
+      isComplete,
+      isBroken,
+      isInGracePeriod,
+    }
+  }
+
+  private isSameDate(date1: Date, date2: Date): boolean {
+    return (
+      date1.getFullYear() === date2.getFullYear() &&
+      date1.getMonth() === date2.getMonth() &&
+      date1.getDate() === date2.getDate()
+    )
+  }
+}

--- a/apps/capsulelabs-api/src/streak-capsule/services/streak-capsule.service.ts
+++ b/apps/capsulelabs-api/src/streak-capsule/services/streak-capsule.service.ts
@@ -1,0 +1,247 @@
+import { Injectable, NotFoundException, BadRequestException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { StreakCapsule, StreakCapsuleStatus } from "../entities/streak-capsule.entity"
+import { StreakCapsuleInteractionLog, StreakInteractionType } from "../entities/streak-capsule-interaction-log.entity"
+import type { CreateStreakCapsuleDto } from "../dto/create-streak-capsule.dto"
+import type { CheckInDto } from "../dto/check-in.dto"
+import type { StreakCapsuleResponseDto, CheckInResponseDto } from "../dto/streak-capsule-response.dto"
+import type { CheckInService } from "./check-in.service"
+import type { StreakCalculationService } from "./streak-calculation.service"
+
+@Injectable()
+export class StreakCapsuleService {
+  private streakCapsuleRepository: Repository<StreakCapsule>
+  private interactionLogRepository: Repository<StreakCapsuleInteractionLog>
+
+  constructor(
+    @InjectRepository(StreakCapsule)
+    streakCapsuleRepository: Repository<StreakCapsule>,
+    @InjectRepository(StreakCapsuleInteractionLog)
+    interactionLogRepository: Repository<StreakCapsuleInteractionLog>,
+    private checkInService: CheckInService,
+    private streakCalculationService: StreakCalculationService,
+  ) {
+    this.streakCapsuleRepository = streakCapsuleRepository
+    this.interactionLogRepository = interactionLogRepository
+  }
+
+  async createCapsule(createCapsuleDto: CreateStreakCapsuleDto): Promise<StreakCapsuleResponseDto> {
+    const capsule = this.streakCapsuleRepository.create({
+      ...createCapsuleDto,
+      timezone: createCapsuleDto.timezone || "UTC",
+      allowGracePeriod: createCapsuleDto.allowGracePeriod || false,
+      gracePeriodHours: createCapsuleDto.gracePeriodHours || 0,
+      expiresAt: createCapsuleDto.expiresAt ? new Date(createCapsuleDto.expiresAt) : null,
+    })
+
+    const savedCapsule = await this.streakCapsuleRepository.save(capsule)
+
+    // Log the creation
+    await this.logInteraction(savedCapsule.userId, savedCapsule.id, StreakInteractionType.CREATED, {
+      capsuleType: savedCapsule.type,
+      requiredStreakDays: savedCapsule.requiredStreakDays,
+    })
+
+    return this.mapToResponseDto(savedCapsule)
+  }
+
+  async getCapsuleById(id: string, userId: string): Promise<StreakCapsuleResponseDto> {
+    const capsule = await this.streakCapsuleRepository.findOne({
+      where: { id, userId },
+    })
+
+    if (!capsule) {
+      throw new NotFoundException("Streak capsule not found")
+    }
+
+    // Update capsule with latest streak data
+    await this.updateCapsuleStreakData(capsule)
+
+    // Log the view
+    await this.logInteraction(userId, id, StreakInteractionType.VIEWED)
+
+    return this.mapToResponseDto(capsule)
+  }
+
+  async getUserCapsules(userId: string): Promise<StreakCapsuleResponseDto[]> {
+    const capsules = await this.streakCapsuleRepository.find({
+      where: { userId },
+      order: { createdAt: "DESC" },
+    })
+
+    // Update all capsules with latest streak data
+    for (const capsule of capsules) {
+      await this.updateCapsuleStreakData(capsule)
+    }
+
+    return capsules.map((capsule) => this.mapToResponseDto(capsule))
+  }
+
+  async checkIn(userId: string, checkInDto: CheckInDto = {}): Promise<CheckInResponseDto> {
+    const timezone = checkInDto.timezone || "UTC"
+
+    try {
+      // Perform the check-in
+      const { checkIn, isNewRecord } = await this.checkInService.checkIn(userId, timezone, checkInDto.metadata)
+
+      // Get all user's streak capsules
+      const capsules = await this.streakCapsuleRepository.find({
+        where: { userId, status: StreakCapsuleStatus.LOCKED },
+      })
+
+      let capsuleUnlocked = false
+      let unlockedCapsule: StreakCapsule | null = null
+
+      // Update all capsules and check for unlocks
+      for (const capsule of capsules) {
+        const streakUpdate = await this.streakCalculationService.updateCapsuleStreak(capsule)
+
+        // Update capsule data
+        capsule.currentStreak = streakUpdate.currentStreak
+        capsule.longestStreak = streakUpdate.longestStreak
+        capsule.totalCheckIns = streakUpdate.totalCheckIns
+        capsule.lastCheckInDate = checkIn.checkInDate
+        capsule.streakStartDate = streakUpdate.currentStreak === 1 ? checkIn.checkInDate : capsule.streakStartDate
+
+        await this.streakCapsuleRepository.save(capsule)
+
+        // Log the check-in for this capsule
+        await this.logInteraction(userId, capsule.id, StreakInteractionType.CHECK_IN, {
+          checkInDate: checkIn.checkInDate,
+          streakDay: checkIn.streakDay,
+          currentStreak: streakUpdate.currentStreak,
+        })
+
+        // Check if streak is complete and unlock capsule
+        if (streakUpdate.isStreakComplete) {
+          capsule.status = StreakCapsuleStatus.UNLOCKED
+          capsule.unlockedAt = new Date()
+          await this.streakCapsuleRepository.save(capsule)
+
+          // Log streak completion and unlock
+          await this.logInteraction(userId, capsule.id, StreakInteractionType.STREAK_COMPLETED, {
+            requiredDays: capsule.requiredStreakDays,
+            completedDays: streakUpdate.currentStreak,
+          })
+
+          await this.logInteraction(userId, capsule.id, StreakInteractionType.UNLOCKED)
+
+          capsuleUnlocked = true
+          unlockedCapsule = capsule
+        }
+      }
+
+      return {
+        success: true,
+        message: `Check-in successful! Current streak: ${checkIn.streakDay} day${checkIn.streakDay !== 1 ? "s" : ""}.`,
+        currentStreak: checkIn.streakDay,
+        isNewRecord,
+        capsuleUnlocked,
+        streakCapsule: unlockedCapsule ? this.mapToResponseDto(unlockedCapsule) : undefined,
+      }
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error
+      }
+      throw new BadRequestException("Failed to check in")
+    }
+  }
+
+  async getStreakStats(userId: string, timezone = "UTC") {
+    return await this.checkInService.getStreakStats(userId, timezone)
+  }
+
+  async getUserCheckIns(userId: string, limit = 30) {
+    return await this.checkInService.getUserCheckIns(userId, limit)
+  }
+
+  private async updateCapsuleStreakData(capsule: StreakCapsule): Promise<void> {
+    const streakUpdate = await this.streakCalculationService.updateCapsuleStreak(capsule)
+
+    // Check if streak was broken
+    if (streakUpdate.isStreakBroken) {
+      await this.logInteraction(capsule.userId, capsule.id, StreakInteractionType.STREAK_BROKEN, {
+        previousStreak: capsule.currentStreak,
+        newStreak: streakUpdate.currentStreak,
+      })
+    }
+
+    // Update capsule data
+    capsule.currentStreak = streakUpdate.currentStreak
+    capsule.longestStreak = streakUpdate.longestStreak
+    capsule.totalCheckIns = streakUpdate.totalCheckIns
+
+    // Reset streak start date if streak is broken
+    if (streakUpdate.currentStreak === 0) {
+      capsule.streakStartDate = null
+    }
+
+    await this.streakCapsuleRepository.save(capsule)
+  }
+
+  private async logInteraction(
+    userId: string,
+    capsuleId: string,
+    type: StreakInteractionType,
+    metadata?: Record<string, any>,
+  ): Promise<void> {
+    const log = this.interactionLogRepository.create({
+      userId,
+      capsuleId,
+      type,
+      metadata,
+    })
+
+    await this.interactionLogRepository.save(log)
+  }
+
+  private mapToResponseDto(capsule: StreakCapsule): StreakCapsuleResponseDto {
+    const progressPercentage = this.streakCalculationService.calculateProgressPercentage(
+      capsule.currentStreak,
+      capsule.requiredStreakDays,
+    )
+
+    const daysRemaining = this.streakCalculationService.calculateDaysRemaining(
+      capsule.currentStreak,
+      capsule.requiredStreakDays,
+    )
+
+    const streakStatus = this.streakCalculationService.getStreakStatus(
+      capsule.currentStreak,
+      capsule.requiredStreakDays,
+      capsule.lastCheckInDate,
+      capsule.allowGracePeriod,
+      capsule.gracePeriodHours,
+      capsule.timezone,
+    )
+
+    return {
+      id: capsule.id,
+      title: capsule.title,
+      description: capsule.description,
+      content: capsule.status === StreakCapsuleStatus.UNLOCKED ? capsule.content : undefined,
+      type: capsule.type,
+      status: capsule.status,
+      userId: capsule.userId,
+      requiredStreakDays: capsule.requiredStreakDays,
+      currentStreak: capsule.currentStreak,
+      longestStreak: capsule.longestStreak,
+      totalCheckIns: capsule.totalCheckIns,
+      lastCheckInDate: capsule.lastCheckInDate,
+      streakStartDate: capsule.streakStartDate,
+      timezone: capsule.timezone,
+      allowGracePeriod: capsule.allowGracePeriod,
+      gracePeriodHours: capsule.gracePeriodHours,
+      unlockedAt: capsule.unlockedAt,
+      expiresAt: capsule.expiresAt,
+      metadata: capsule.metadata,
+      createdAt: capsule.createdAt,
+      updatedAt: capsule.updatedAt,
+      progressPercentage,
+      daysRemaining,
+      canCheckInToday: true, // This would be calculated based on timezone and last check-in
+      isStreakActive: streakStatus.isActive,
+    }
+  }
+}

--- a/apps/capsulelabs-api/src/streak-capsule/streak-capsule.module.ts
+++ b/apps/capsulelabs-api/src/streak-capsule/streak-capsule.module.ts
@@ -1,0 +1,17 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { StreakCapsuleController } from "./controllers/streak-capsule.controller"
+import { StreakCapsuleService } from "./services/streak-capsule.service"
+import { CheckInService } from "./services/check-in.service"
+import { StreakCalculationService } from "./services/streak-calculation.service"
+import { StreakCapsule } from "./entities/streak-capsule.entity"
+import { DailyCheckIn } from "./entities/daily-check-in.entity"
+import { StreakCapsuleInteractionLog } from "./entities/streak-capsule-interaction-log.entity"
+
+@Module({
+  imports: [TypeOrmModule.forFeature([StreakCapsule, DailyCheckIn, StreakCapsuleInteractionLog])],
+  controllers: [StreakCapsuleController],
+  providers: [StreakCapsuleService, CheckInService, StreakCalculationService],
+  exports: [StreakCapsuleService, CheckInService],
+})
+export class StreakCapsuleModule {}


### PR DESCRIPTION
This feature enables capsules to be unlocked only when a user successfully solves a riddle or lateral thinking puzzle. It adds a layer of challenge and engagement to the unlocking process.

### 🤔 Feature Highlights:

* Retrieves riddles from internal DB or external API
* Enforces a **12-hour cooldown** per user per attempt
* Validates submitted answers before unlocking
* Integrates with the existing capsule unlock service

### 🛠️ Tasks Completed:

* Created or connected to riddle database/API
* Built answer validation logic
* Set user-specific rate limits (1 attempt / 12 hrs)
* Linked puzzle-solving to capsule unlocking flow

closes #55
closes #56
closes #57
